### PR TITLE
fix: update wildcard route syntax for Express v5 compatibility

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -231,7 +231,7 @@ app.get('/api', (req, res) => {
 });
 
 // 404 handler for API routes
-app.use('/api/*', (req, res) => {
+app.use('/api/*path', (req, res) => {
   res.status(404).json({
     success: false,
     error: 'API endpoint not found',
@@ -259,7 +259,7 @@ app.use((err, req, res, next) => {
 // Serve index.html for all other non-API routes (SPA fallback)
 // This must be last to avoid catching API routes
 if (config.staticFiles.path) {
-  app.get('*', (req, res) => {
+  app.get('*path', (req, res) => {
     const indexPath = path.resolve(config.staticFiles.path, 'index.html');
     res.sendFile(indexPath);
   });


### PR DESCRIPTION
## Summary
- Update bare `*` wildcard routes in `backend/src/app.js` to use named `*path` parameters required by Express v5's `path-to-regexp`
- Fixes API 404 handler (`/api/*` → `/api/*path`) and SPA fallback (`*` → `*path`)

## Test plan
- [ ] CI tests pass (40/40 unit tests passing locally)
- [ ] Verify `/api/nonexistent` returns 404 JSON response
- [ ] Verify non-API routes serve `index.html` fallback

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)