### PR TITLE
fix: prevent chunked expiry from incorrectly expiring valid advisories

### DIFF
--- a/backend/src/ingestion/noaa-ingestor.js
+++ b/backend/src/ingestion/noaa-ingestor.js
@@ -321,25 +321,32 @@ async function ingestNOAAData() {
     console.log(`Marked ${endTimeExpired.affectedRows} advisories as expired (end_time passed)`);
     
     // Step 6: Mark advisories not in current batch as expired.
-    // Chunked into 500-ID batches to avoid MySQL max_allowed_packet limits
-    // and parser stress when advisory counts are high during major events.
+    // Uses the full processedExternalIds set in a single query to avoid
+    // incorrectly expiring valid advisories that would be missing from
+    // individual chunks.
     console.log('\nMarking missing advisories as expired...');
     let expiredCount = 0;
 
     if (processedExternalIds.length > 0) {
-      const CHUNK_SIZE = 500;
-      for (let i = 0; i < processedExternalIds.length; i += CHUNK_SIZE) {
-        const chunk = processedExternalIds.slice(i, i + CHUNK_SIZE);
+      // Safeguard: if NOAA returned very few alerts compared to active
+      // advisories, log a warning (may indicate partial API response)
+      const [activeCount] = await db.query(
+        `SELECT COUNT(*) as cnt FROM advisories WHERE status = 'active' AND external_id IS NOT NULL`
+      );
+      const activeTotal = activeCount[0].cnt;
+      if (activeTotal > 0 && processedExternalIds.length < activeTotal * 0.1) {
+        console.warn(`⚠️  WARNING: Only ${processedExternalIds.length} IDs processed vs ${activeTotal} active advisories — possible partial NOAA response. Skipping expiry.`);
+      } else {
         const [result] = await db.query(`
           UPDATE advisories
           SET status = 'expired', last_updated = CURRENT_TIMESTAMP
           WHERE status = 'active'
             AND external_id IS NOT NULL
             AND external_id NOT IN (?)
-        `, [chunk]);
-        expiredCount += result.affectedRows;
+        `, [processedExternalIds]);
+        expiredCount = result.affectedRows;
+        console.log(`Marked ${expiredCount} advisories as expired`);
       }
-      console.log(`Marked ${expiredCount} advisories as expired`);
     }
     
     // Step 6: Create historical snapshots for trend analysis


### PR DESCRIPTION
## Summary
- Fixed bug where NOT IN expiry query was chunked into 500-ID batches, causing chunk 1 to expire advisories whose IDs only appeared in chunk 2
- Replaced chunked loop with a single query using the full `processedExternalIds` set
- Added safeguard: skips expiry if processed count is <10% of active advisories (protects against partial NOAA API responses)

## Test plan
- [ ] Run ingestion with mock data containing >500 alerts to verify no false expirations
- [ ] Verify safeguard triggers warning when NOAA returns suspiciously few alerts
- [ ] Confirm normal ingestion flow still correctly expires stale advisories

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)