### PR TITLE
fix: enable export features and remove Coming Soon badges

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -176,14 +176,14 @@
                                 </a></li>
                                 <li><hr class="dropdown-divider"></li>
                                 <li><h6 class="dropdown-header">Advanced Reports</h6></li>
-                                <li><a class="dropdown-item disabled text-muted" href="#">
-                                    <i class="bi bi-file-earmark-person"></i> Executive Briefing <span class="badge bg-secondary ms-1">Coming Soon</span>
+                                <li><a class="dropdown-item" href="#" id="exportExecutive">
+                                    <i class="bi bi-file-earmark-person"></i> Executive Briefing
                                 </a></li>
-                                <li><a class="dropdown-item disabled text-muted" href="#">
-                                    <i class="bi bi-file-earmark-text"></i> Incident Report <span class="badge bg-secondary ms-1">Coming Soon</span>
+                                <li><a class="dropdown-item" href="#" id="exportIncident">
+                                    <i class="bi bi-file-earmark-text"></i> Incident Report
                                 </a></li>
-                                <li><a class="dropdown-item disabled text-muted" href="#">
-                                    <i class="bi bi-filetype-csv"></i> Export CSV <span class="badge bg-secondary ms-1">Coming Soon</span>
+                                <li><a class="dropdown-item" href="#" id="exportCSV">
+                                    <i class="bi bi-filetype-csv"></i> Export CSV
                                 </a></li>
                             </ul>
                         </div>

--- a/frontend/js/page-index.js
+++ b/frontend/js/page-index.js
@@ -394,21 +394,21 @@
                 const advisories = await advisoriesResponse.json();
 
                 // Extract offices array from the response
-                const sites = Array.isArray(officesData.data) ? officesData.data : [];
+                const offices = Array.isArray(officesData.data) ? officesData.data : [];
 
                 // Export based on type
                 switch(type) {
                     case 'csv':
-                        StormScoutExport.exportOfficesToCSV(sites);
+                        StormScoutExport.exportOfficesToCSV(offices);
                         break;
                     case 'executive':
-                        StormScoutExport.generateHTMLReport({ sites, advisories, overview }, 'executive');
+                        StormScoutExport.generateHTMLReport({ offices, advisories, overview }, 'executive');
                         break;
                     case 'incident':
-                        StormScoutExport.generateHTMLReport({ sites, advisories }, 'incident');
+                        StormScoutExport.generateHTMLReport({ offices, advisories }, 'incident');
                         break;
                     case 'summary':
-                        StormScoutExport.generateHTMLReport({ sites }, 'summary');
+                        StormScoutExport.generateHTMLReport({ offices }, 'summary');
                         break;
                     default:
                         console.error('Unknown export type:', type);
@@ -422,4 +422,6 @@
         // Event listeners for export buttons (CSP-compliant)
         document.getElementById('exportPrintPDF').addEventListener('click', (e) => { e.preventDefault(); StormScoutExport.printToPDF(); });
         document.getElementById('exportShareLink').addEventListener('click', (e) => { e.preventDefault(); StormScoutExport.copyShareableLink(); });
-        // Advanced export features coming soon
+        document.getElementById('exportExecutive').addEventListener('click', (e) => { e.preventDefault(); exportCurrentData('executive'); });
+        document.getElementById('exportIncident').addEventListener('click', (e) => { e.preventDefault(); exportCurrentData('incident'); });
+        document.getElementById('exportCSV').addEventListener('click', (e) => { e.preventDefault(); exportCurrentData('csv'); });


### PR DESCRIPTION
## Summary
- Removed 'Coming Soon' badges and `disabled` class from Executive Briefing, Incident Report, and Export CSV dropdown items
- Added click handlers wired to existing `exportCurrentData()` function
- Fixed property name mismatch (`sites` → `offices`) so data correctly reaches export templates

**Note:** Operational Status 'Coming Soon' badges (CLOSED, RESTRICTED, PENDING, OPEN cards) are retained — that feature is a placeholder for future manual status management.

## Test plan
- [ ] Click Executive Briefing — verify it opens a print-ready briefing
- [ ] Click Incident Report — verify it generates a report with office/advisory data
- [ ] Click Export CSV — verify CSV file downloads with correct column headers
- [ ] Verify Print/Save PDF and Copy Shareable Link still work

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)