### PR TITLE
chore: clean .gitignore of organization-specific references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,12 +57,12 @@ convert-models.sh
 # Runtime state
 backend/.last-ingestion.json
 
-# USPS internal site data (Issue #150)
+# Legacy site data exports
 storm-scout-sites*.csv
 scout-sites*
 staging/
 
-# USPS-internal migration
+# Superseded migration
 backend/src/data/migrations/20260220-add-site-reference-table.sql
 
 # Build-time data artifacts (Issue #152)


### PR DESCRIPTION
## Summary
- Replaced "USPS internal site data" comment with "Legacy site data exports"
- Replaced "USPS-internal migration" comment with "Superseded migration"

## Test plan
- [ ] Grep .gitignore for "USPS" — should return no matches

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)