### PR TITLE
docs: standardize office count to 300 across all documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,18 +3,20 @@
 **Project**: Storm Scout  
 **Purpose**: Office-focused weather advisory dashboard for operations teams
 **Production URL**: https://your-domain.example.com
-**Status**: Active — Production deployment (1363 locations, zip-code based)
+**Status**: Active — Production deployment (300 locations, zip-code based)
 **Last Updated**: 2026-03-10
 
 ---
 
 ## Project Overview
 
-Storm Scout is a weather advisory monitoring system that consolidates active NOAA weather alerts and operational signals by location to help operations teams quickly identify which of the 1382 monitored locations may be impacted during severe weather events.
+Storm Scout is a weather advisory monitoring system that consolidates active NOAA weather alerts and operational signals by location to help operations teams quickly identify which of the 300 monitored locations may be impacted during severe weather events.
+
+> **Canonical office count:** The source of truth for the office count is `backend/src/data/offices.json` (currently 300). All documentation should reference this file when citing the number of monitored locations.
 
 ### Key Capabilities
 - **Real-time NOAA Data**: Automatic ingestion every 15 minutes from NOAA Weather API
-- **1452 Monitored Locations**: Monitoring offices across all 50 US states and territories
+- **300 Monitored Locations**: Monitoring offices across all 50 US states and territories
 - **Smart Filtering**: 94 NOAA alert types across 5 impact levels (CRITICAL, HIGH, MODERATE, LOW, INFO)
 - **Operational Status**: Automatically calculated (Open/Closed/At Risk) based on advisory severity
 - **Duplicate Prevention**: Multi-level deduplication using external_id, VTEC event IDs, and VTEC codes; natural-key fallback `(office_id, advisory_type, source, start_time)` guards against malformed payloads where both fields are absent
@@ -39,8 +41,8 @@ Storm Scout is a weather advisory monitoring system that consolidates active NOA
 - **Map Marker Clustering**: `leaflet.markercluster` groups overlapping markers; cluster icons colored by highest child severity
 - **CI Pipeline**: `.github/workflows/ci.yml` runs `npm ci`, `npm audit --audit-level=high`, `npm test` on push/PR
 - **Alert Detail Modal**: View full NOAA narrative descriptions on office-detail page
-- **UGC Code Matching**: Precise zone/county-level alert geo-targeting for all 1489 monitored locations
-- **Office Import**: One-time CSV import via `import-offices.js` to load 1440 monitored locations from zip-based CSV
+- **UGC Code Matching**: Precise zone/county-level alert geo-targeting for all 300 monitored locations
+- **Office Import**: One-time CSV import via `import-offices.js` to load 300 monitored locations from zip-based CSV
 - **Weather Observations**: Current conditions (temperature, humidity, wind, pressure, visibility, etc.) from nearest NWS observation station, updated every 15 minutes
 - **Global Architecture Planned**: Adapter-based design for ECCC (Canada), MeteoAlarm (EU), SMN (Mexico) — expert-reviewed, ready for implementation
 - **Safe Deployment**: `deploy.sh` calls `POST /api/admin/pause-ingestion` (API-key authenticated) before rsync; waits for active cycle to finish; ERR trap resumes on failure; admin endpoints in `routes/admin.js` also available for manual ops control
@@ -80,7 +82,7 @@ Storm Scout is a weather advisory monitoring system that consolidates active NOA
 
 ### Data Sources
 - **NOAA Weather API**: Primary source for all weather advisories and current weather observations
-- **NWS Observation Stations**: Current conditions from 1166 ICAO weather stations mapped by office lat/lon
+- **NWS Observation Stations**: Current conditions from ICAO weather stations mapped by office lat/lon
 - **VTEC Codes**: Valid Time Event Code parsing for deduplication
 - **UGC Codes**: County/zone codes for precise geo-matching
 
@@ -157,7 +159,7 @@ strom-scout/
 │   │   │       └── noaa-alerts-snapshot.json  # 540-alert NOAA fixture for regression testing
 │   │   └── data/
 │   │       ├── schema.sql            # MySQL schema
-│   │       ├── offices.json            # 1694 monitored locations
+│   │       ├── offices.json            # 300 monitored locations
 │   │       └── migrations/
 │   │           └── rollback-global-alert-sources.sql  # MariaDB-compatible rollback for global tables
 │   └── package.json
@@ -185,7 +187,7 @@ strom-scout/
 ### Database Schema
 
 **6 Main Tables**:
-1. **offices** - 1495 monitored locations (office_code = 5-digit zip, includes observation_station ICAO code)
+1. **offices** - 300 monitored locations (office_code = 5-digit zip, includes observation_station ICAO code)
 2. **advisories** - Weather alerts mapped to offices (dynamic, updated every 15 min)
 3. **office_observations** - Current weather conditions per office (replaced each ingestion cycle, no history)
 4. **office_status** - Operational status tracking (manual overrides + auto-calculation)
@@ -294,7 +296,7 @@ CWA is the 3-letter NWS office code responsible for a geographic area. Used for 
 Each office is mapped to its nearest NWS observation station via `/points/{lat},{lon}` → `observationStations` URL. The mapping stores an ICAO code (e.g., KORD, KJFK) in `offices.observation_station`.
 
 **Key facts**:
-- 1552 offices map to 1209 unique stations (some stations serve multiple nearby offices, e.g., KNYC→3 NYC offices)
+- 300 offices map to observation stations (some stations serve multiple nearby offices, e.g., KNYC→3 NYC offices)
 - Some stations are non-ICAO mesonet/cooperative stations (e.g., E3225, WTHC1) — these report fewer fields (often missing wind, text_description)
 - NWS does NOT include `precipitationLast6Hours` in latest observation responses — this field was removed from the schema
 - Staleness detection logs a warning when `observed_at` > 2 hours old (some stations report infrequently)
@@ -335,7 +337,7 @@ npm test               # Run unit tests (Jest)
 npm run test:watch     # Run tests in watch mode
 
 # Database
-npm run init-db        # Initialize schema + load 1638 monitored locations
+npm run init-db        # Initialize schema + load 300 monitored locations
 npm run seed-db        # Load seed/sample data
 
 # Data Operations
@@ -430,7 +432,7 @@ ssh -p 22 your_user@your-server "touch ~/storm-scout/tmp/restart.txt"
 - ✅ External ID unique constraint
 - ✅ Automated cleanup system
 - ✅ Production deployment
-- ✅ 1428 monitored locations loaded
+- ✅ 300 monitored locations loaded
 - ✅ 15-minute NOAA ingestion working
 - ✅ Severity validation (defaults Unknown to Minor)
 - ✅ Database CHECK constraint on severity
@@ -440,13 +442,13 @@ ssh -p 22 your_user@your-server "touch ~/storm-scout/tmp/restart.txt"
 - ✅ Input validation with express-validator (all endpoints)
 - ✅ Storm Scout Severity Alignment (uses internal categories instead of NOAA raw severity)
 - ✅ 4-tier severity grouping (Offices Requiring Attention matches Weather Impact colors)
-- ✅ UGC code matching for all 1635 monitored locations (precise zone/county geo-targeting)
+- ✅ UGC code matching for all 300 monitored locations (precise zone/county geo-targeting)
 - ✅ Fixed state-level fallback to only apply to offices without UGC codes
 - ✅ office import workflow (import-offices.js converts CSV → offices.json)
 - ✅ Dashboard cards show office_code + office_name (index.html, advisories.html, offices.html)
 - ✅ Office detail alert cards show headline, *WHAT description, *WHEN timing, issued, source (expires removed)
 - ✅ Weather observations from nearest NWS station (temperature, humidity, wind, pressure, visibility, clouds, etc.)
-- ✅ Observation station mapping for all 1555 monitored locations (1269 unique stations)
+- ✅ Observation station mapping for all 300 monitored locations
 - ✅ Observation review: data accuracy validated, failed stations remapped, stale detection added
 - ✅ Local development environment with MariaDB, Jest, and smoke test script
 - ✅ Frontend API client auto-detects local vs production (no hardcoded URL)
@@ -582,7 +584,7 @@ FROM advisories WHERE office_id = (SELECT id FROM offices WHERE office_code = '8
 ### Database Backup & Disaster Recovery
 
 **Critical Data**: The Storm Scout database (`storm_scout`) contains:
-- **Static**: 1704 monitored locations (offices table) - can be reloaded from `backend/src/data/offices.json`
+- **Static**: 300 monitored locations (offices table) - can be reloaded from `backend/src/data/offices.json`
 - **Dynamic**: Active weather advisories (advisories table) - repopulates automatically within 15 minutes
 - **Transient**: Weather observations (office_observations table) - repopulates automatically within 15 minutes
 - **Historical**: Advisory snapshots (advisory_history table) - **IRREPLACEABLE** if lost
@@ -656,7 +658,7 @@ FROM advisories WHERE office_id = (SELECT id FROM offices WHERE office_code = '8
    
    | Scenario | Impact | Recovery Time | Steps |
    |----------|--------|---------------|-------|
-   | **Offices table lost** | 🔴 Critical - No advisories can be matched | 5 min | Run `npm run seed-db` from backend (1565 monitored locations) |
+   | **Offices table lost** | 🔴 Critical - No advisories can be matched | 5 min | Run `npm run seed-db` from backend (300 monitored locations) |
    | **Advisories table lost** | 🟡 Moderate - Data repopulates automatically | 15 min | Next ingestion cycle will rebuild active advisories |
    | **Advisory_history lost** | 🟠 High - Historical trends lost permanently | N/A | Must restore from backup (no auto-recovery) |
    | **Office_status lost** | 🔴 Critical - Manual operations decisions lost | Varies | Restore from backup; Operations must re-enter manual overrides |
@@ -745,7 +747,7 @@ The smoke test script (`backend/scripts/smoke-test.sh`) automates pre-deploy val
 1. Starts the server in the background
 2. Waits for it to be ready
 3. Validates all key API endpoints (health, offices, advisories, status, filters, observations)
-4. Verifies 1670 monitored locations are loaded
+4. Verifies 300 monitored locations are loaded
 5. Confirms frontend is served correctly
 6. **innerHTML XSS safety audit** — scans all frontend `.html` and `.js` files for unsafe `innerHTML` usage without `html` tagged template (reports as warning, does not fail build)
 7. Shuts down the server and reports results
@@ -1084,7 +1086,7 @@ All security documentation is in `docs/security/`:
 
 `docs/ARCHITECTURE.md` documents:
 - System overview and data flow diagram
-- Current tested scale thresholds (1450 locations, 40-connection pool)
+- Current tested scale thresholds (300 locations, 40-connection pool)
 - Scale ceilings per component (UI, backend, database, infrastructure)
 - Five triggers for a scale review (500 locations, 2M advisory rows, etc.)
 - Minimum required changes before operating at >500 locations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,7 +155,7 @@ docs: add JSDoc to page-advisories.js (closes #128)
 
 ## Project Context
 
-Storm Scout is a weather advisory dashboard monitoring 1610 office locations across all 50 US states. It ingests NOAA weather advisories every 15 minutes, matches them to offices by UGC zone codes, and surfaces operational impact through a browser-based dashboard.
+Storm Scout is a weather advisory dashboard monitoring 300 office locations across all 50 US states. It ingests NOAA weather advisories every 15 minutes, matches them to offices by UGC zone codes, and surfaces operational impact through a browser-based dashboard.
 
 The project is designed as a reference implementation demonstrating:
 - Production-quality Node.js + Express API patterns

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -67,7 +67,7 @@ docker exec -i storm-scout-db mariadb -u storm_scout -plocaldev storm_scout_dev 
 
 ```bash
 node backend/src/scripts/import-offices.js /path/to/locations.csv
-# Output: backend/src/data/offices.json (1351 offices)
+# Output: backend/src/data/offices.json (300 offices)
 npm run seed-db
 ```
 
@@ -205,7 +205,7 @@ If a migration causes issues in production:
 # Health check (database, ingestion state, data integrity)
 curl http://localhost:3000/health
 
-# Confirm 1703 offices loaded
+# Confirm 300 offices loaded
 curl http://localhost:3000/api/offices | python3 -c \
   "import json,sys; d=json.load(sys.stdin); print(d['count'], 'offices')"
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Storm Scout consolidates active weather advisories and operational signals by lo
 ## ✨ Features
 
 ### Core Functionality
-- **1299 Locations** - Monitors offices across all 50 states and US territories, identified by 5-digit zip codes
+- **300 Locations** - Monitors offices across all 50 states and US territories, identified by 5-digit zip codes
 - **Real-Time NOAA Weather Data** - Automatic ingestion of weather alerts every 15 minutes
 - **Automated Advisory Cleanup** - Removes duplicate and expired advisories after each ingestion
 - **Automatic Alert Expiration** - Alerts marked expired when their `end_time` passes
@@ -95,7 +95,7 @@ Storm Scout consolidates active weather advisories and operational signals by lo
 
 ## Quick Start
 
-> **Terminology:** Throughout this documentation, "locations" and "offices" refer to the same 1412 monitored facilities. The codebase and API use "office" consistently.
+> **Terminology:** Throughout this documentation, "locations" and "offices" refer to the same 300 monitored facilities. The codebase and API use "office" consistently.
 
 ### Prerequisites
 
@@ -205,7 +205,7 @@ storm-scout/
 │   │   ├── routes/      # REST API endpoints
 │   │   ├── ingestion/   # NOAA alert + observation fetching
 │   │   ├── scripts/     # Maintenance scripts (office import, station mapping)
-│   │   └── data/        # Schema, offices.json (1343 locations), migrations/
+│   │   └── data/        # Schema, offices.json (300 locations), migrations/
 │   ├── package.json
 │   └── README.md
 │
@@ -234,7 +234,7 @@ storm-scout/
 **Backend:** Node.js 18+, Express, MariaDB 11 (Docker), mysql2, node-cron, axios
 **Middleware:** node-cache (caching), compression (gzip), express-rate-limit, express-validator
 **Frontend:** HTML5, Bootstrap 5.3.8, Vanilla JavaScript, localStorage API
-**Data:** NOAA Weather API (94 alert types, 1140 observation stations), 1393 office locations
+**Data:** NOAA Weather API (94 alert types, 1140 observation stations), 300 office locations
 **Deployment:** Ubuntu Linux, systemd user service, Docker (MariaDB)
 **Storage:** MySQL async/await models, unique indexes for data integrity
 
@@ -265,7 +265,7 @@ npm start
 - `GET /health` - Readiness and operational health check
 - `GET /api/status/overview` - Dashboard statistics (with filter-aware frontend calculations)
 - `GET /api/advisories/active` - All active advisories. Supports `?page=N&limit=N` pagination; returns full dataset by default for backward compatibility.
-- `GET /api/offices` - All 1496 offices
+- `GET /api/offices` - All 300 offices
 - `GET /api/status/offices-impacted` - Offices with Closed or At Risk status
 - `GET /api/filters` - Available filter presets
 - `GET /api/filters/types/all` - All NOAA alert types by impact level

--- a/backend/README.md
+++ b/backend/README.md
@@ -78,7 +78,7 @@ Import locations from CSV, then seed:
 
 ```bash
 node src/scripts/import-offices.js /path/to/locations.csv
-# Output: src/data/offices.json (1524 offices)
+# Output: src/data/offices.json (300 offices)
 
 npm run seed-db
 ```
@@ -97,7 +97,7 @@ Server starts at **http://localhost:3000** and runs initial NOAA ingestion immed
 
 ### Offices
 
-- `GET /api/offices` — Get all 1294 offices (filters: state, region)
+- `GET /api/offices` — Get all 300 offices (filters: state, region)
 - `GET /api/offices/states` — List of states
 - `GET /api/offices/regions` — List of regions
 - `GET /api/offices/:id` — Get office by ID with status and advisories
@@ -226,7 +226,7 @@ backend/
 │   └── data/
 │       ├── schema.sql                # Full database schema
 │       ├── seed.sql                  # Sample notices + default office statuses
-│       ├── offices.json              # 1710 offices (zip-code based)
+│       ├── offices.json              # 300 offices (zip-code based)
 │       └── migrations/               # SQL migration files (date-prefixed)
 ├── .env.example
 ├── package.json

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Storm Scout — Architecture & Scale Considerations
 
 **Last Updated:** 2026-03-10
-**Current Production Scale:** 1680 locations
+**Current Production Scale:** 300 locations
 
 ---
 
@@ -42,14 +42,14 @@ Bootstrap 5.3 Frontend  (client-side filter/sort/aggregate over full dataset)
 
 ## Scale Ceilings by Component
 
-The system is designed and tested for 1671 locations. The following table documents implicit scale ceilings — points where a specific component will degrade or require architectural work before scaling further.
+The system is designed and tested for 300 locations. The following table documents implicit scale ceilings — points where a specific component will degrade or require architectural work before scaling further.
 
 ### UI / Frontend
 
 | Component | Current approach | Ceiling | Risk at ceiling |
 |-----------|-----------------|---------|-----------------|
 | Advisory list (`advisories.html`) | Full dataset fetched client-side; filtered in JS | ~2,000 advisories before noticeable render lag | Client memory and DOM re-render time grow linearly |
-| Offices list (`offices.html`) | Full 1499-office list in memory | ~1,000 offices | Acceptable; search is debounced but re-renders all visible rows |
+| Offices list (`offices.html`) | Full 300-office list in memory | ~1,000 offices | Acceptable; search is debounced but re-renders all visible rows |
 | Map (`map.html`) | `leaflet.markercluster` groups markers | ~5,000 markers before cluster performance degrades | Cluster calculation is O(n log n); acceptable to ~3,000 |
 | Update countdown | Single-page `setInterval` | No ceiling | N/A |
 | localStorage preferences | Single JSON blob | No ceiling | N/A |
@@ -61,7 +61,7 @@ The system is designed and tested for 1671 locations. The following table docume
 | Component | Current approach | Ceiling | Risk at ceiling |
 |-----------|-----------------|---------|-----------------|
 | `getAllTrends()` | Single SQL query + O(n) JS grouping (post-#105 fix) | ~10,000 history rows/query | Acceptable; further growth requires index tuning or partitioning |
-| `getImpacted()` | Derived-table LEFT JOIN (post-#107 fix) | No practical ceiling at 1372 offices | Well-optimized |
+| `getImpacted()` | Derived-table LEFT JOIN (post-#107 fix) | No practical ceiling at 300 offices | Well-optimized |
 | Ingestion cycle | Sequential per-office UGC matching | ~500 offices before cycle exceeds 30s | NOAA API rate limits (500ms between calls) are the primary constraint |
 | Connection pool | 40 connections (configurable) | Governed by MariaDB `max_connections` | Raise `DB_POOL_LIMIT` and verify `SHOW VARIABLES LIKE 'max_connections'` before scaling |
 | Rate limiter | 30,000 req/60 min per IP (default; configurable via `RATE_LIMIT_API_MAX` env var) | Accommodates corporate NAT environments where many users share one IP | N/A |
@@ -72,7 +72,7 @@ The system is designed and tested for 1671 locations. The following table docume
 | Component | Current approach | Ceiling | Risk at ceiling |
 |-----------|-----------------|---------|-----------------|
 | `advisories` table | InnoDB, no partitioning | ~5M rows before query plans degrade without partitioning | `idx_advisories_status_time` index covers common queries well to this range |
-| `advisory_history` table | InnoDB, no partitioning; 30-day TTL cleanup | ~500K rows (1460 offices × 4 snapshots/day × 30 days = 36K rows/month) | Safe at current scale; partition by month at ~300K rows/month |
+| `advisory_history` table | InnoDB, no partitioning; 30-day TTL cleanup | ~500K rows (300 offices × 4 snapshots/day × 30 days = 36K rows/month) | Safe at current scale; partition by month at ~300K rows/month |
 | `offices` table | Full table scan acceptable | No ceiling at 1640 | Static data; cached aggressively |
 | Backup strategy | Not automated | Any scale | See Planned work below |
 

--- a/docs/DATA-DICTIONARY.md
+++ b/docs/DATA-DICTIONARY.md
@@ -20,7 +20,7 @@ Complete column reference for all database tables. Schema source: `backend/src/d
 
 ## offices
 
-**Purpose:** Static reference list of all 1684 office locations. Loaded from `backend/src/data/offices.json` at database initialization and rarely modified thereafter.
+**Purpose:** Static reference list of all 300 office locations. Loaded from `backend/src/data/offices.json` at database initialization and rarely modified thereafter.
 
 | Column | Type | Nullable | Description |
 |--------|------|----------|-------------|

--- a/docs/QUICK-REFERENCE.md
+++ b/docs/QUICK-REFERENCE.md
@@ -114,7 +114,7 @@ curl http://localhost:3000/api/status/overview | python3 -m json.tool
 ### Offices and advisories
 
 ```bash
-# All 1287 offices
+# All 300 offices
 curl http://localhost:3000/api/offices | python3 -c \
   "import json,sys; d=json.load(sys.stdin); print(d['count'], 'offices')"
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -97,7 +97,7 @@ Dashboard summary statistics.
 
 #### GET `/api/offices`
 
-Get all 1560 office locations.
+Get all 300 office locations.
 
 **Response**:
 ```json


### PR DESCRIPTION
## Summary
- Updated 20+ stale office count references (ranging 1,166–1,710) to canonical **300** across 9 files
- Canonical source: `backend/src/data/offices.json` (300 entries)
- Added canonical source note to AGENTS.md
- CHANGELOG.md entries left unchanged (historical records)

### Files updated
- README.md (4 refs)
- AGENTS.md (12 refs + canonical source note)
- CONTRIBUTING.md (1 ref)
- DEPLOY.md (2 refs)
- docs/ARCHITECTURE.md (5 refs)
- docs/api.md (1 ref)
- backend/README.md (3 refs)
- docs/QUICK-REFERENCE.md (1 ref)
- docs/DATA-DICTIONARY.md (1 ref)

## Test plan
- [ ] Grep all `.md` and `.html` files for 4-digit numbers near "office/location" — only CHANGELOG.md should have non-300 counts
- [ ] Verify `python3 -c "import json; print(len(json.load(open('backend/src/data/offices.json'))))"` returns 300

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)