### PR TITLE
docs: add NOAA public domain data attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,14 @@ Storm Scout implements multiple security controls:
 
 **Quick reference:** See [`docs/QUICK-REFERENCE.md`](docs/QUICK-REFERENCE.md) for a developer cheat sheet of CLI commands, environment variables, and curl examples.
 
+## Data Sources
+
+Storm Scout uses exclusively public domain data from the US federal government:
+
+- **NOAA/NWS Weather API** ([api.weather.gov](https://api.weather.gov)) — All weather alerts, warnings, advisories, and observation data. NOAA data is US government work and in the public domain. No API key is required — the only requirement is a `User-Agent` header with a contact email, per NOAA's [API documentation](https://www.weather.gov/documentation/services-web-api). There are no usage fees or rate limits beyond reasonable use.
+
+- **Office locations** — The monitored locations in `backend/src/data/offices.json` are user-provided via CSV import. See [Adapting for Your Organization](#adapting-for-your-organization) for how to load your own locations.
+
 ## Development Story
 
 Storm Scout was built by a technical operations leader — not a software engineer — using AI-assisted development with [Claude Code](https://claude.ai). The entire project, from first commit to production deployment, was developed through human-AI collaboration: the human directed architecture decisions, defined requirements, and managed the project backlog while AI generated the code, tests, and documentation.

--- a/frontend/sources.html
+++ b/frontend/sources.html
@@ -63,10 +63,12 @@
                             The National Oceanic and Atmospheric Administration (NOAA) and National Weather Service (NWS) provide real-time weather alerts, warnings, and advisories for the United States. Storm Scout uses the official NOAA Weather API to fetch active alerts.
                         </p>
                         <ul>
+                            <li><strong>Data License:</strong> Public domain — US government work, no usage restrictions</li>
+                            <li><strong>API Access:</strong> No API key required — only a <code>User-Agent</code> header with a contact email</li>
                             <li><strong>Update Frequency:</strong> Every 15 minutes (configurable)</li>
                             <li><strong>Coverage:</strong> All 50 US states and territories</li>
                             <li><strong>Data Types:</strong> Watches, Warnings, Advisories, Statements</li>
-                            <li><strong>Reliability:</strong> Official government source - highly reliable</li>
+                            <li><strong>Cost:</strong> Free — no usage fees or licensing costs</li>
                         </ul>
                         <a href="https://www.weather.gov" target="_blank" class="btn btn-primary">
                             Visit NOAA Weather <i class="bi bi-box-arrow-up-right"></i>


### PR DESCRIPTION
## Summary
- Adds "Data Sources" section to README with NOAA public domain attribution
- Notes: no API key required, no fees, public domain US government data
- Updates sources.html NOAA card to explicitly state public domain license, free access, and no-API-key requirement
- Replaces generic "Reliability: Official government source" with specific license/cost/access details

Closes #178