### PR TITLE
chore: remove stray console.log statements from frontend JS

### DIFF
--- a/frontend/js/export.js
+++ b/frontend/js/export.js
@@ -586,7 +586,6 @@ const StormScoutExport = {
         if (params.has('preset')) {
             const preset = params.get('preset');
             localStorage.setItem('selectedFilterPreset', preset);
-            console.log('Applied filter preset from URL:', preset);
         }
         
         // Apply custom filters
@@ -596,7 +595,6 @@ const StormScoutExport = {
                 const filters = JSON.parse(filtersJSON);
                 localStorage.setItem('customFilters', JSON.stringify(filters));
                 localStorage.setItem('selectedFilterPreset', 'CUSTOM');
-                console.log('Applied custom filters from URL');
             } catch (e) {
                 console.error('Error decoding URL filters:', e);
             }

--- a/frontend/js/page-filters.js
+++ b/frontend/js/page-filters.js
@@ -122,7 +122,6 @@
             const saved = localStorage.getItem(STORAGE_KEY);
             if (saved) {
                 currentFilters = JSON.parse(saved);
-                console.log('Loaded saved preferences');
             } else {
                 // Use default preset
                 applyPreset(DEFAULT_PRESET, false);


### PR DESCRIPTION
## Summary
- Removes 3 debug `console.log` calls from `page-filters.js` and `export.js`
- Retains `console.error` and `console.warn` (intentional error reporting)
- Full audit of all `frontend/js/` files confirms no other `console.log` calls remain

Closes #180