### PR TITLE
fix: event listener registration order in page-map.js

### DIFF
--- a/frontend/js/page-map.js
+++ b/frontend/js/page-map.js
@@ -274,8 +274,7 @@
         document.getElementById('toggleSevere').addEventListener('click', () => toggleFilter('Severe'));
         document.getElementById('toggleModerate').addEventListener('click', () => toggleFilter('Moderate'));
 
-        map?.on('moveend', updateVisibleCount);
-
         // Initialize
         initMap();
+        map.on('moveend', updateVisibleCount);
         loadMapData();


### PR DESCRIPTION
## Summary
- Moves `map.on('moveend', updateVisibleCount)` to after `initMap()` where `map` is defined
- Previously ran at module parse time when `map` was undefined — optional chaining silently skipped it
- The "X offices visible" counter now updates correctly when panning/zooming
- No other event listeners in the file have similar ordering issues

Closes #182