### PR TITLE
refactor: replace setTimeout hack for print dialog in export.js

### DIFF
--- a/frontend/js/export.js
+++ b/frontend/js/export.js
@@ -116,10 +116,8 @@ const StormScoutExport = {
         printWindow.document.write(reportHTML);
         printWindow.document.close();
         
-        // Trigger print dialog after load
-        setTimeout(() => {
-            printWindow.print();
-        }, 500);
+        // Trigger print dialog after content loads
+        printWindow.onload = () => printWindow.print();
     },
     
     /**


### PR DESCRIPTION
## Summary
- Replaces `setTimeout(() => printWindow.print(), 500)` with `printWindow.onload = () => printWindow.print()`
- The 500ms delay was fragile — too short on slow machines, unnecessarily long on fast ones
- Notification animation timeouts are intentional CSS timing and left unchanged

Closes #184