### PR TITLE
refactor: extract temperature rendering into shared helper

### DIFF
--- a/frontend/js/page-advisories.js
+++ b/frontend/js/page-advisories.js
@@ -173,17 +173,7 @@
             let rowsHtml = '';
             sorted.forEach(site => {
                 const obs = observationsMap[site.office_code];
-                const tempF = obs ? cToF(obs.temperature_c) : null;
-                const tempC = obs && obs.temperature_c != null ? Math.round(parseFloat(obs.temperature_c)) : null;
-                let tempSpan = '';
-                if (tempF != null) {
-                    const stale = isStale(obs.observed_at);
-                    if (stale) {
-                        tempSpan = `<span class="text-muted ms-3"><span aria-hidden="true">🌡️</span> ${tempF}°F / ${tempC}°C</span> <small class="text-danger"><strong>${escapeHtml(obs.station_id)} OFFLINE</strong></small>`;
-                    } else {
-                        tempSpan = `<span class="text-muted ms-3"><span aria-hidden="true">🌡️</span> ${tempF}°F / ${tempC}°C</span>`;
-                    }
-                }
+                const tempSpan = renderTemperatureHTML(obs);
                 const alertCount = site.advisories.length;
                 const sevLower = site.highest_severity.toLowerCase();
 
@@ -402,24 +392,7 @@
             const highestAlert = site.highest_severity_advisory;
             const headlineText = truncate(highestAlert.headline || '', 120);
 
-            // Temperature display
-            let tempHtml = '';
-            if (obs && obs.temperature_c != null) {
-                const tempF = cToF(obs.temperature_c);
-                const tempC = Math.round(parseFloat(obs.temperature_c));
-                const stale = isStale(obs.observed_at);
-                if (stale) {
-                    tempHtml = `<div class="temp-display">
-                        <span class="text-dark"><span aria-hidden="true">🌡️</span> ${tempF}°F / ${tempC}°C</span>
-                        <small class="text-danger ms-2"><strong>${escapeHtml(obs.station_id)} - OFFLINE</strong></small>
-                    </div>`;
-                } else {
-                    tempHtml = `<div class="temp-display">
-                        <span class="text-dark"><span aria-hidden="true">🌡️</span> ${tempF}°F / ${tempC}°C</span>
-                        <small class="text-muted ms-2">${timeAgo(obs.observed_at)}</small>
-                    </div>`;
-                }
-            }
+            const tempHtml = renderTemperatureHTML(obs);
 
             return html`
                 <div class="col-lg-6 col-12">

--- a/frontend/js/page-index.js
+++ b/frontend/js/page-index.js
@@ -280,24 +280,7 @@
             const advisory = site.highest_severity_advisory || {};
             const headlineText = truncate(advisory.headline || '', 120);
 
-            // Temperature display
-            let tempHtml = '';
-            if (obs && obs.temperature_c != null) {
-                const tempF = cToF(obs.temperature_c);
-                const tempC = Math.round(parseFloat(obs.temperature_c));
-                const stale = isStale(obs.observed_at);
-                if (stale) {
-                    tempHtml = `<div class="temp-display">
-                        <span class="text-dark"><span aria-hidden="true">🌡️</span> ${tempF}°F / ${tempC}°C</span>
-                        <small class="text-danger ms-2"><strong>${escapeHtml(obs.station_id)} - OFFLINE</strong></small>
-                    </div>`;
-                } else {
-                    tempHtml = `<div class="temp-display">
-                        <span class="text-dark"><span aria-hidden="true">🌡️</span> ${tempF}°F / ${tempC}°C</span>
-                        <small class="text-muted ms-2">${timeAgo(obs.observed_at)}</small>
-                    </div>`;
-                }
-            }
+            const tempHtml = renderTemperatureHTML(obs);
 
             return html`
                 <div class="col-lg-4 col-md-6 col-12 mb-3">

--- a/frontend/js/page-map.js
+++ b/frontend/js/page-map.js
@@ -126,19 +126,8 @@
                 const marker = L.marker([office.latitude, office.longitude], { icon: customIcon, severity });
 
                 // Create popup content using html tagged template for XSS prevention
-                // Build temperature HTML
                 const obs = observationsMap[office.office_code];
-                let tempHtml = '';
-                if (obs && obs.temperature_c != null) {
-                    const tempF = cToF(obs.temperature_c);
-                    const tempC = Math.round(parseFloat(obs.temperature_c));
-                    const stale = isStale(obs.observed_at);
-                    if (stale) {
-                        tempHtml = `<span><span aria-hidden="true">🌡️</span> ${tempF}°F / ${tempC}°C <small class="text-danger"><strong>${escapeHtml(obs.station_id)} - OFFLINE</strong></small></span>`;
-                    } else {
-                        tempHtml = `<span><span aria-hidden="true">🌡️</span> ${tempF}°F / ${tempC}°C <small class="text-muted">${timeAgo(obs.observed_at)}</small></span>`;
-                    }
-                }
+                const tempHtml = renderTemperatureHTML(obs);
 
                 const headlineText = truncate(office.highest_severity_advisory.headline || '', 80);
 

--- a/frontend/js/page-office-detail.js
+++ b/frontend/js/page-office-detail.js
@@ -131,17 +131,9 @@
 
             // Temperature display
             const tempContainer = document.getElementById('officeTempDisplay');
-            if (obs && obs.temperature_c != null) {
-                const tempF = cToF(obs.temperature_c);
-                const tempC = Math.round(parseFloat(obs.temperature_c));
-                const stale = isStale(obs.observed_at);
-                if (stale) {
-                    tempContainer.innerHTML = html`<span class="text-dark"><span aria-hidden="true">🌡️</span> ${raw(`${tempF}`)}°F / ${raw(`${tempC}`)}°C</span>
-                        <small class="text-danger ms-2"><strong>${obs.station_id} - OFFLINE</strong></small>`;
-                } else {
-                    tempContainer.innerHTML = html`<span class="text-dark"><span aria-hidden="true">🌡️</span> ${raw(`${tempF}`)}°F / ${raw(`${tempC}`)}°C</span>
-                        <small class="text-muted ms-2">${raw(timeAgo(obs.observed_at))}</small>`;
-                }
+            const tempHtml = renderTemperatureHTML(obs);
+            if (tempHtml) {
+                tempContainer.innerHTML = tempHtml;
             }
 
             const headerCard = document.getElementById('officeHeaderCard');

--- a/frontend/js/page-offices.js
+++ b/frontend/js/page-offices.js
@@ -148,24 +148,7 @@
                 const headlineText = advisory ? truncate(advisory.headline || '', 120) : '';
                 const obs = observationsMap[office.office_code];
 
-                // Temperature display
-                let tempHtml = '';
-                if (obs && obs.temperature_c != null) {
-                    const tempF = cToF(obs.temperature_c);
-                    const tempC = Math.round(parseFloat(obs.temperature_c));
-                    const stale = isStale(obs.observed_at);
-                    if (stale) {
-                        tempHtml = `<div class="temp-display">
-                            <span class="text-dark"><span aria-hidden="true">🌡️</span> ${tempF}°F / ${tempC}°C</span>
-                            <small class="text-danger ms-2"><strong>${escapeHtml(obs.station_id)} - OFFLINE</strong></small>
-                        </div>`;
-                    } else {
-                        tempHtml = `<div class="temp-display">
-                            <span class="text-dark"><span aria-hidden="true">🌡️</span> ${tempF}°F / ${tempC}°C</span>
-                            <small class="text-muted ms-2">${timeAgo(obs.observed_at)}</small>
-                        </div>`;
-                    }
-                }
+                const tempHtml = renderTemperatureHTML(obs);
 
                 return html`
                 <div class="col-md-6 col-lg-4 mb-3">

--- a/frontend/js/utils.js
+++ b/frontend/js/utils.js
@@ -284,6 +284,23 @@ function isStale(observedAt) {
 }
 
 /**
+ * Render temperature display HTML from an observation object.
+ * Returns empty string if observation is null or has no temperature data.
+ * @param {Object} observation - Observation with temperature_c, observed_at, station_id
+ * @returns {string} HTML string for temperature display
+ */
+function renderTemperatureHTML(observation) {
+    if (!observation || observation.temperature_c == null) return '';
+    const tempF = cToF(observation.temperature_c);
+    const tempC = Math.round(parseFloat(observation.temperature_c));
+    const stale = isStale(observation.observed_at);
+    if (stale) {
+        return `<div class="temp-display"><span class="text-dark"><span aria-hidden="true">🌡️</span> ${tempF}°F / ${tempC}°C</span> <small class="text-danger ms-2"><strong>${escapeHtml(observation.station_id)} - OFFLINE</strong></small></div>`;
+    }
+    return `<div class="temp-display"><span class="text-dark"><span aria-hidden="true">🌡️</span> ${tempF}°F / ${tempC}°C</span> <small class="text-muted ms-2">${timeAgo(observation.observed_at)}</small></div>`;
+}
+
+/**
  * Truncate a string to a maximum length, appending ellipsis if truncated.
  * @param {string} str - String to truncate
  * @param {number} max - Maximum length


### PR DESCRIPTION
## Summary
- Adds `renderTemperatureHTML(observation)` to `utils.js` consolidating temperature display logic
- Replaces duplicated code across 5 page-level JS files (-88 lines, +25 lines)
- Reuses existing `cToF()`, `isStale()`, `timeAgo()`, and `escapeHtml()` from utils.js
- Handles: C-to-F conversion, stale observation detection, OFFLINE badge, thermometer emoji, time-ago display

**Files changed:** `utils.js`, `page-index.js`, `page-offices.js`, `page-advisories.js`, `page-office-detail.js`, `page-map.js`

Closes #179