### PR TITLE
chore: standardize indentation to 4 spaces in page-level JS files

### DIFF
--- a/frontend/js/page-advisories.js
+++ b/frontend/js/page-advisories.js
@@ -1,148 +1,146 @@
-        /**
-         * page-advisories.js
-         * Advisories page — renders active NOAA advisories in card and table views;
-         * applies user filter preferences; supports free-text search with debounce.
-         *
-         * Key responsibilities:
-         *   - Loads all active NOAA advisories and weather observations in parallel
-         *   - Applies user-configured alert-type filters (AlertFilters), state, severity,
-         *     and free-text search
-         *   - Supports two views: card view (office cards) and grouped table view
-         *   - Shows a filter-warning banner when hidden alerts include critical types
-         *   - Handles ?severity= URL parameter to pre-select a severity filter on load
-         *
-         * State variables:
-         *   allAdvisories          - Current working set of advisories (may be pre-filtered
-         *                            by applyURLParameters if ?severity= is set)
-         *   allAdvisoriesUnfiltered - Full raw advisory list used for filter-warning diff
-         *   observationsMap        - Keyed by office_code; provides temperature readings
-         *   currentView            - 'card' or 'table'; controls which renderer runs
-         *
-         * External dependencies (globals from loaded scripts):
-         *   API               - backend REST client (api.js)
-         *   AlertFilters      - user preference engine (alert-filters.js)
-         *   OfficeAggregator  - aggregation/severity helpers (office-aggregator.js)
-         *   debounce, html, raw, escapeHtml, truncate, cToF, isStale, timeAgo,
-         *   formatDate, getSeverityBadge, getActionBadge, renderEmptyHtml,
-         *   renderErrorHtml, renderFilterWarning  — from utils.js / shared helpers
-         */
+/**
+ * page-advisories.js
+ * Advisories page — renders active NOAA advisories in card and table views;
+ * applies user filter preferences; supports free-text search with debounce.
+ *
+ * Key responsibilities:
+ *   - Loads all active NOAA advisories and weather observations in parallel
+ *   - Applies user-configured alert-type filters (AlertFilters), state, severity,
+ *     and free-text search
+ *   - Supports two views: card view (office cards) and grouped table view
+ *   - Shows a filter-warning banner when hidden alerts include critical types
+ *   - Handles ?severity= URL parameter to pre-select a severity filter on load
+ *
+ * State variables:
+ *   allAdvisories          - Current working set of advisories (may be pre-filtered
+ *                            by applyURLParameters if ?severity= is set)
+ *   allAdvisoriesUnfiltered - Full raw advisory list used for filter-warning diff
+ *   observationsMap        - Keyed by office_code; provides temperature readings
+ *   currentView            - 'card' or 'table'; controls which renderer runs
+ *
+ * External dependencies (globals from loaded scripts):
+ *   API               - backend REST client (api.js)
+ *   AlertFilters      - user preference engine (alert-filters.js)
+ *   OfficeAggregator  - aggregation/severity helpers (office-aggregator.js)
+ *   debounce, html, raw, escapeHtml, truncate, cToF, isStale, timeAgo,
+ *   formatDate, getSeverityBadge, getActionBadge, renderEmptyHtml,
+ *   renderErrorHtml, renderFilterWarning  — from utils.js / shared helpers
+ */
 
-        let allAdvisories = [];
-        let allAdvisoriesUnfiltered = [];
-        let observationsMap = {};
-        let currentView = 'card';
+let allAdvisories = [];
+let allAdvisoriesUnfiltered = [];
+let observationsMap = {};
+let currentView = 'card';
 
-        /**
-         * Determine whether an advisory type should be shown under a given named filter preset.
-         * When no filterName is supplied the user's saved AlertFilters preferences govern.
-         * When a preset name is supplied the preset's includeCategories and excludeTypes
-         * fields are applied directly — enabling the filter dropdown to override preferences
-         * without permanently mutating localStorage.
-         *
-         * @param {string} alertType   - NOAA alert type string (e.g. "Tornado Warning")
-         * @param {string} filterName  - Optional named preset key from AlertFilters.filterConfigs;
-         *                               pass '' or null to use the user's active preferences
-         * @returns {boolean} True if the alert type should be included in the current view
-         */
-        function shouldIncludeAlertType(alertType, filterName) {
-            if (!filterName || filterName === '') {
-                return AlertFilters.shouldIncludeAlertType(alertType);
-            }
+/**
+ * Determine whether an advisory type should be shown under a given named filter preset.
+ * When no filterName is supplied the user's saved AlertFilters preferences govern.
+ * When a preset name is supplied the preset's includeCategories and excludeTypes
+ * fields are applied directly — enabling the filter dropdown to override preferences
+ * without permanently mutating localStorage.
+ *
+ * @param {string} alertType   - NOAA alert type string (e.g. "Tornado Warning")
+ * @param {string} filterName  - Optional named preset key from AlertFilters.filterConfigs;
+ *                               pass '' or null to use the user's active preferences
+ * @returns {boolean} True if the alert type should be included in the current view
+ */
+function shouldIncludeAlertType(alertType, filterName) {
+    if (!filterName || filterName === '') {
+        return AlertFilters.shouldIncludeAlertType(alertType);
+    }
 
-            const config = AlertFilters.filterConfigs[filterName];
-            if (!config) return true;
+    const config = AlertFilters.filterConfigs[filterName];
+    if (!config) return true;
 
-            if (config.excludeTypes && config.excludeTypes.includes(alertType)) {
-                return false;
-            }
+    if (config.excludeTypes && config.excludeTypes.includes(alertType)) {
+        return false;
+    }
 
-            let impactLevel = null;
-            for (const [level, types] of Object.entries(AlertFilters.alertTypesByLevel)) {
-                if (types.includes(alertType)) {
-                    impactLevel = level;
-                    break;
-                }
-            }
-
-            if (!impactLevel) return true;
-            return config.includeCategories && config.includeCategories.includes(impactLevel);
+    let impactLevel = null;
+    for (const [level, types] of Object.entries(AlertFilters.alertTypesByLevel)) {
+        if (types.includes(alertType)) {
+            impactLevel = level;
+            break;
         }
+    }
 
-        /**
-         * Fetch all active advisories and current weather observations, then
-         * build the observations lookup map and trigger the initial render.
-         * Advisories and observations are loaded in parallel via Promise.all to
-         * minimise total wait time; an observation failure is non-fatal (caught
-         * inline) so the page still loads if the observations endpoint is down.
-         *
-         * @returns {Promise<void>}
-         */
-        async function loadAdvisories() {
-            try {
-                const [data, obsData] = await Promise.all([
-                    API.getActiveAdvisories(),
-                    API.getObservations().catch(() => [])
-                ]);
+    if (!impactLevel) return true;
+    return config.includeCategories && config.includeCategories.includes(impactLevel);
+}
 
-                // Build observations lookup by office_code
-                observationsMap = {};
-                obsData.forEach(obs => { observationsMap[obs.office_code] = obs; });
+/**
+ * Fetch all active advisories and current weather observations, then
+ * build the observations lookup map and trigger the initial render.
+ * Advisories and observations are loaded in parallel via Promise.all to
+ * minimise total wait time; an observation failure is non-fatal (caught
+ * inline) so the page still loads if the observations endpoint is down.
+ *
+ * @returns {Promise<void>}
+ */
+async function loadAdvisories() {
+    try {
+        const [data, obsData] = await Promise.all([API.getActiveAdvisories(), API.getObservations().catch(() => [])]);
 
-                allAdvisoriesUnfiltered = data;
-                allAdvisories = data;
+        // Build observations lookup by office_code
+        observationsMap = {};
+        obsData.forEach((obs) => {
+            observationsMap[obs.office_code] = obs;
+        });
 
-                // Populate state filter
-                const states = [...new Set(data.map(a => a.state))].sort();
-                const stateSelect = document.getElementById('stateFilter');
-                stateSelect.innerHTML = '<option value="">All States</option>';
-                states.forEach(state => {
-                    const option = document.createElement('option');
-                    option.value = state;
-                    option.textContent = state;
-                    stateSelect.appendChild(option);
-                });
+        allAdvisoriesUnfiltered = data;
+        allAdvisories = data;
 
-                // Initial render
-                renderAll();
-            } catch (error) {
-                document.getElementById('cardViewContainer').innerHTML =
-                    renderErrorHtml('Failed to load advisories');
-                document.getElementById('advisoriesTable').innerHTML =
-                    `<tr><td colspan="11"><div class="alert alert-danger mb-0" role="alert"><i class="bi bi-exclamation-triangle-fill me-2"></i>Failed to load advisories</div></td></tr>`;
-            }
-        }
+        // Populate state filter
+        const states = [...new Set(data.map((a) => a.state))].sort();
+        const stateSelect = document.getElementById('stateFilter');
+        stateSelect.innerHTML = '<option value="">All States</option>';
+        states.forEach((state) => {
+            const option = document.createElement('option');
+            option.value = state;
+            option.textContent = state;
+            stateSelect.appendChild(option);
+        });
 
-        // getActionBadge() is defined in js/utils.js
+        // Initial render
+        renderAll();
+    } catch (error) {
+        document.getElementById('cardViewContainer').innerHTML = renderErrorHtml('Failed to load advisories');
+        document.getElementById('advisoriesTable').innerHTML =
+            `<tr><td colspan="11"><div class="alert alert-danger mb-0" role="alert"><i class="bi bi-exclamation-triangle-fill me-2"></i>Failed to load advisories</div></td></tr>`;
+    }
+}
 
-        /**
-         * Render all offices with active advisories as a grouped HTML table.
-         * Each office is represented by a clickable header row summarising its
-         * highest severity and alert count, followed by one sub-row per alert
-         * sorted highest-severity-first within each office group.
-         * Summary stats (unique offices, critical/severe counts, etc.) are also
-         * re-rendered so they stay in sync when the filter state changes in table view.
-         *
-         * @param {Array<Object>} sites             - Aggregated office objects from
-         *                                            OfficeAggregator.aggregateByOffice
-         * @param {Array<Object>} filteredAdvisories - Flat advisory array used to
-         *                                            compute summary stats
-         * @returns {void}
-         */
-        function renderGroupedTable(sites, filteredAdvisories) {
-            const tbody = document.getElementById('advisoriesTable');
-            const statsContainer = document.getElementById('summaryStatsContainer');
+// getActionBadge() is defined in js/utils.js
 
-            if (sites.length === 0) {
-                tbody.innerHTML = `<tr><td colspan="11">${renderEmptyHtml('cloud-sun', 'No active advisories', 'No advisories match your current filter settings.')}</td></tr>`;
-                statsContainer.innerHTML = '';
-                return;
-            }
+/**
+ * Render all offices with active advisories as a grouped HTML table.
+ * Each office is represented by a clickable header row summarising its
+ * highest severity and alert count, followed by one sub-row per alert
+ * sorted highest-severity-first within each office group.
+ * Summary stats (unique offices, critical/severe counts, etc.) are also
+ * re-rendered so they stay in sync when the filter state changes in table view.
+ *
+ * @param {Array<Object>} sites             - Aggregated office objects from
+ *                                            OfficeAggregator.aggregateByOffice
+ * @param {Array<Object>} filteredAdvisories - Flat advisory array used to
+ *                                            compute summary stats
+ * @returns {void}
+ */
+function renderGroupedTable(sites, filteredAdvisories) {
+    const tbody = document.getElementById('advisoriesTable');
+    const statsContainer = document.getElementById('summaryStatsContainer');
 
-            // Render summary stats (keeps stats updated when filters change in table view)
-            const stats = OfficeAggregator.getSummaryStats(filteredAdvisories, sites);
-            const extremeCount = sites.filter(s => s.highest_severity === 'Extreme').length;
-            const severeCount = sites.filter(s => s.highest_severity === 'Severe').length;
-            statsContainer.innerHTML = `
+    if (sites.length === 0) {
+        tbody.innerHTML = `<tr><td colspan="11">${renderEmptyHtml('cloud-sun', 'No active advisories', 'No advisories match your current filter settings.')}</td></tr>`;
+        statsContainer.innerHTML = '';
+        return;
+    }
+
+    // Render summary stats (keeps stats updated when filters change in table view)
+    const stats = OfficeAggregator.getSummaryStats(filteredAdvisories, sites);
+    const extremeCount = sites.filter((s) => s.highest_severity === 'Extreme').length;
+    const severeCount = sites.filter((s) => s.highest_severity === 'Severe').length;
+    statsContainer.innerHTML = `
                 <div class="col-12">
                     <div class="summary-stats">
                         <div class="summary-stat">
@@ -165,20 +163,18 @@
                 </div>
             `;
 
-            // Sort offices by office_code ascending
-            const sorted = [...sites].sort((a, b) =>
-                a.office_code.localeCompare(b.office_code, undefined, { numeric: true })
-            );
+    // Sort offices by office_code ascending
+    const sorted = [...sites].sort((a, b) => a.office_code.localeCompare(b.office_code, undefined, { numeric: true }));
 
-            let rowsHtml = '';
-            sorted.forEach(site => {
-                const obs = observationsMap[site.office_code];
-                const tempSpan = renderTemperatureHTML(obs);
-                const alertCount = site.advisories.length;
-                const sevLower = site.highest_severity.toLowerCase();
+    let rowsHtml = '';
+    sorted.forEach((site) => {
+        const obs = observationsMap[site.office_code];
+        const tempSpan = renderTemperatureHTML(obs);
+        const alertCount = site.advisories.length;
+        const sevLower = site.highest_severity.toLowerCase();
 
-                // Office header row
-                rowsHtml += `<tr class="office-group-header office-group-${escapeHtml(sevLower)}" data-office-code="${escapeHtml(site.office_code)}">
+        // Office header row
+        rowsHtml += `<tr class="office-group-header office-group-${escapeHtml(sevLower)}" data-office-code="${escapeHtml(site.office_code)}">
                     <td colspan="11">
                         <div style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:0.5rem;">
                             <div style="display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;">
@@ -195,112 +191,118 @@
                     </td>
                 </tr>`;
 
-                // Sort alerts: highest severity first
-                const sortedAdvs = [...site.advisories].sort((a, b) =>
-                    OfficeAggregator.getSeverityRank(b.severity) - OfficeAggregator.getSeverityRank(a.severity)
-                );
+        // Sort alerts: highest severity first
+        const sortedAdvs = [...site.advisories].sort(
+            (a, b) => OfficeAggregator.getSeverityRank(b.severity) - OfficeAggregator.getSeverityRank(a.severity)
+        );
 
-                // Alert sub-rows
-                sortedAdvs.forEach(adv => {
-                    const headlineShort = truncate(adv.headline || '', 80);
-                    rowsHtml += html`<tr class="office-group-row">
-                        <td colspan="6" class="ps-4 text-muted">
-                            <small>${headlineShort}</small>
-                        </td>
-                        <td><strong>${adv.advisory_type}</strong></td>
-                        <td>${raw(`<span class="badge ${getSeverityBadge(adv.severity)}">${escapeHtml(adv.severity)}</span>`)}</td>
-                        <td>${raw(getActionBadge(adv.vtec_action))}</td>
-                        <td>${adv.source}</td>
-                        <td>${raw(formatDate(adv.last_updated))}</td>
-                    </tr>`;
-                });
-            });
+        // Alert sub-rows
+        sortedAdvs.forEach((adv) => {
+            const headlineShort = truncate(adv.headline || '', 80);
+            rowsHtml += html`<tr class="office-group-row">
+                <td colspan="6" class="ps-4 text-muted">
+                    <small>${headlineShort}</small>
+                </td>
+                <td><strong>${adv.advisory_type}</strong></td>
+                <td>
+                    ${raw(`<span class="badge ${getSeverityBadge(adv.severity)}">${escapeHtml(adv.severity)}</span>`)}
+                </td>
+                <td>${raw(getActionBadge(adv.vtec_action))}</td>
+                <td>${adv.source}</td>
+                <td>${raw(formatDate(adv.last_updated))}</td>
+            </tr>`;
+        });
+    });
 
-            tbody.innerHTML = rowsHtml;
+    tbody.innerHTML = rowsHtml;
 
-            // Click handlers: office header rows navigate to office detail
-            tbody.querySelectorAll('.office-group-header').forEach(row => {
-                row.addEventListener('click', () => {
-                    window.location.href = `office-detail.html?office=${row.dataset.officeCode}`;
-                });
-            });
-        }
+    // Click handlers: office header rows navigate to office detail
+    tbody.querySelectorAll('.office-group-header').forEach((row) => {
+        row.addEventListener('click', () => {
+            window.location.href = `office-detail.html?office=${row.dataset.officeCode}`;
+        });
+    });
+}
 
-        /**
-         * Entry point for all re-renders — delegates to filterAndRender so that
-         * every render path always applies the current filter state.
-         * Named `renderAll` for external callers (e.g. event listeners) that
-         * need a stable reference even if the internal implementation changes.
-         *
-         * @returns {void}
-         */
-        function renderAll() {
-            filterAndRender();
-        }
+/**
+ * Entry point for all re-renders — delegates to filterAndRender so that
+ * every render path always applies the current filter state.
+ * Named `renderAll` for external callers (e.g. event listeners) that
+ * need a stable reference even if the internal implementation changes.
+ *
+ * @returns {void}
+ */
+function renderAll() {
+    filterAndRender();
+}
 
-        /**
-         * Read all active filter controls, apply them to the full advisory list,
-         * aggregate results by office, then delegate to the correct view renderer.
-         * The dual-view design (card vs. table) keeps the same filter+aggregate
-         * pipeline but hands off to different renderers so each view can optimise
-         * its own DOM structure independently.
-         *
-         * @returns {void}
-         */
-        function filterAndRender() {
-            const search = document.getElementById('searchBox').value.toLowerCase();
-            const alertTypeFilter = document.getElementById('alertTypeFilter').value;
-            const state = document.getElementById('stateFilter').value;
-            const severity = document.getElementById('severityFilter').value;
-            const dedupEnabled = document.getElementById('dedupToggle').checked;
+/**
+ * Read all active filter controls, apply them to the full advisory list,
+ * aggregate results by office, then delegate to the correct view renderer.
+ * The dual-view design (card vs. table) keeps the same filter+aggregate
+ * pipeline but hands off to different renderers so each view can optimise
+ * its own DOM structure independently.
+ *
+ * @returns {void}
+ */
+function filterAndRender() {
+    const search = document.getElementById('searchBox').value.toLowerCase();
+    const alertTypeFilter = document.getElementById('alertTypeFilter').value;
+    const state = document.getElementById('stateFilter').value;
+    const severity = document.getElementById('severityFilter').value;
+    const dedupEnabled = document.getElementById('dedupToggle').checked;
 
-            // Filter advisories
-            let filtered = allAdvisories.filter(adv => {
-                if (search && !(adv.office_code.toLowerCase().includes(search) || adv.office_name.toLowerCase().includes(search))) return false;
-                if (alertTypeFilter && !shouldIncludeAlertType(adv.advisory_type, alertTypeFilter)) return false;
-                if (state && adv.state !== state) return false;
-                if (severity && adv.severity !== severity) return false;
-                return true;
-            });
+    // Filter advisories
+    let filtered = allAdvisories.filter((adv) => {
+        if (
+            search &&
+            !(adv.office_code.toLowerCase().includes(search) || adv.office_name.toLowerCase().includes(search))
+        )
+            return false;
+        if (alertTypeFilter && !shouldIncludeAlertType(adv.advisory_type, alertTypeFilter)) return false;
+        if (state && adv.state !== state) return false;
+        if (severity && adv.severity !== severity) return false;
+        return true;
+    });
 
-            // Show filter warning
-            renderFilterWarning(allAdvisoriesUnfiltered, filtered);
+    // Show filter warning
+    renderFilterWarning(allAdvisoriesUnfiltered, filtered);
 
-            // Aggregate by office
-            const aggregatedSites = OfficeAggregator.aggregateByOffice(filtered, { deduplicateZones: dedupEnabled });
+    // Aggregate by office
+    const aggregatedSites = OfficeAggregator.aggregateByOffice(filtered, { deduplicateZones: dedupEnabled });
 
-            // Render based on current view
-            if (currentView === 'card') {
-                renderCardView(aggregatedSites, filtered);
-            } else {
-                renderGroupedTable(aggregatedSites, filtered);
-            }
-        }
+    // Render based on current view
+    if (currentView === 'card') {
+        renderCardView(aggregatedSites, filtered);
+    } else {
+        renderGroupedTable(aggregatedSites, filtered);
+    }
+}
 
-        /**
-         * Show or clear the filter-warning banner.
-         * The banner is shown when the user's active filter settings hide at least
-         * one advisory; it escalates to a critical style when any hidden advisory
-         * has Extreme or Severe severity so operators cannot inadvertently miss
-         * high-impact events.
-         *
-         * @param {Array<Object>} allAdv      - Unfiltered advisory list
-         * @param {Array<Object>} filteredAdv - Currently visible advisory list after filters
-         * @returns {void}
-         */
-        function renderFilterWarning(allAdv, filteredAdv) {
-            const warning = OfficeAggregator.getFilterWarning(allAdv, filteredAdv);
-            const container = document.getElementById('filterWarningContainer');
+/**
+ * Show or clear the filter-warning banner.
+ * The banner is shown when the user's active filter settings hide at least
+ * one advisory; it escalates to a critical style when any hidden advisory
+ * has Extreme or Severe severity so operators cannot inadvertently miss
+ * high-impact events.
+ *
+ * @param {Array<Object>} allAdv      - Unfiltered advisory list
+ * @param {Array<Object>} filteredAdv - Currently visible advisory list after filters
+ * @returns {void}
+ */
+function renderFilterWarning(allAdv, filteredAdv) {
+    const warning = OfficeAggregator.getFilterWarning(allAdv, filteredAdv);
+    const container = document.getElementById('filterWarningContainer');
 
-            if (!warning) {
-                container.innerHTML = '';
-                return;
-            }
+    if (!warning) {
+        container.innerHTML = '';
+        return;
+    }
 
-            const criticalClass = warning.has_critical ? 'filter-warning-critical' : '';
-            const criticalText = warning.has_critical ? ` (${warning.critical_hidden} CRITICAL)` : '';
+    const criticalClass = warning.has_critical ? 'filter-warning-critical' : '';
+    const criticalText = warning.has_critical ? ` (${warning.critical_hidden} CRITICAL)` : '';
 
-            container.innerHTML = `
+    container.innerHTML = `
                 <div class="col-12">
                     <div class="filter-warning-banner ${criticalClass}">
                         <div class="filter-warning-content">
@@ -320,35 +322,39 @@
                 </div>
             `;
 
-            // Attach event listener after inserting HTML
-            document.getElementById('showAllAlertsBtn').addEventListener('click', showAllAlerts);
-        }
+    // Attach event listener after inserting HTML
+    document.getElementById('showAllAlertsBtn').addEventListener('click', showAllAlerts);
+}
 
-        /**
-         * Render the card-view grid of impacted offices.
-         * One Bootstrap card is emitted per aggregated office, sorted ascending
-         * by office code. The summary stats bar is re-rendered alongside the
-         * cards so it reflects the current filter state.
-         *
-         * @param {Array<Object>} sites             - Aggregated office objects
-         * @param {Array<Object>} originalAdvisories - Flat advisory array for stats calculation
-         * @returns {void}
-         */
-        function renderCardView(sites, originalAdvisories) {
-            const container = document.getElementById('cardViewContainer');
-            const statsContainer = document.getElementById('summaryStatsContainer');
+/**
+ * Render the card-view grid of impacted offices.
+ * One Bootstrap card is emitted per aggregated office, sorted ascending
+ * by office code. The summary stats bar is re-rendered alongside the
+ * cards so it reflects the current filter state.
+ *
+ * @param {Array<Object>} sites             - Aggregated office objects
+ * @param {Array<Object>} originalAdvisories - Flat advisory array for stats calculation
+ * @returns {void}
+ */
+function renderCardView(sites, originalAdvisories) {
+    const container = document.getElementById('cardViewContainer');
+    const statsContainer = document.getElementById('summaryStatsContainer');
 
-            if (sites.length === 0) {
-                container.innerHTML = renderEmptyHtml('cloud-sun', 'No advisories match your filters', 'Try adjusting your filter settings to see more results.');
-                statsContainer.innerHTML = '';
-                return;
-            }
+    if (sites.length === 0) {
+        container.innerHTML = renderEmptyHtml(
+            'cloud-sun',
+            'No advisories match your filters',
+            'Try adjusting your filter settings to see more results.'
+        );
+        statsContainer.innerHTML = '';
+        return;
+    }
 
-            // Render summary stats
-            const stats = OfficeAggregator.getSummaryStats(originalAdvisories, sites);
-            const extremeCount = sites.filter(s => s.highest_severity === 'Extreme').length;
-            const severeCount = sites.filter(s => s.highest_severity === 'Severe').length;
-            statsContainer.innerHTML = `
+    // Render summary stats
+    const stats = OfficeAggregator.getSummaryStats(originalAdvisories, sites);
+    const extremeCount = sites.filter((s) => s.highest_severity === 'Extreme').length;
+    const severeCount = sites.filter((s) => s.highest_severity === 'Severe').length;
+    statsContainer.innerHTML = `
                 <div class="col-12">
                     <div class="summary-stats">
                         <div class="summary-stat">
@@ -371,189 +377,223 @@
                 </div>
             `;
 
-            // Render office cards (sorted by office code ascending)
-            const sorted = [...sites].sort((a, b) =>
-                a.office_code.localeCompare(b.office_code, undefined, { numeric: true })
-            );
-            container.innerHTML = sorted.map(office => renderOfficeCard(office, observationsMap[office.office_code])).join('');
-        }
+    // Render office cards (sorted by office code ascending)
+    const sorted = [...sites].sort((a, b) => a.office_code.localeCompare(b.office_code, undefined, { numeric: true }));
+    container.innerHTML = sorted
+        .map((office) => renderOfficeCard(office, observationsMap[office.office_code]))
+        .join('');
+}
 
-        /**
-         * Build and return the HTML string for a single office advisory card.
-         * Includes the highest-severity alert summary, zone count, action badges,
-         * and current temperature if an observation is available.
-         *
-         * @param {Object}      site - Aggregated office object from OfficeAggregator
-         * @param {Object|null} obs  - Weather observation for this office, or null
-         * @returns {string} HTML string for the card column element
-         */
-        function renderOfficeCard(site, obs) {
-            const severityClass = `office-card-${escapeHtml(site.highest_severity.toLowerCase())}`;
-            const highestAlert = site.highest_severity_advisory;
-            const headlineText = truncate(highestAlert.headline || '', 120);
+/**
+ * Build and return the HTML string for a single office advisory card.
+ * Includes the highest-severity alert summary, zone count, action badges,
+ * and current temperature if an observation is available.
+ *
+ * @param {Object}      site - Aggregated office object from OfficeAggregator
+ * @param {Object|null} obs  - Weather observation for this office, or null
+ * @returns {string} HTML string for the card column element
+ */
+function renderOfficeCard(site, obs) {
+    const severityClass = `office-card-${escapeHtml(site.highest_severity.toLowerCase())}`;
+    const highestAlert = site.highest_severity_advisory;
+    const headlineText = truncate(highestAlert.headline || '', 120);
 
-            const tempHtml = renderTemperatureHTML(obs);
+    const tempHtml = renderTemperatureHTML(obs);
 
-            return html`
-                <div class="col-lg-6 col-12">
-                    <a href="office-detail.html?office=${site.office_code}" class="text-decoration-none">
-                        <div class="card office-card card-clickable ${raw(severityClass)}">
-                            <div class="office-card-header">
-                                <div>
-                                    <h5 class="office-card-title text-dark">
-                                        <strong>${site.office_code}</strong> - ${site.office_name}
-                                    </h5>
-                                    <div class="office-card-location">
-                                        <i class="bi bi-geo-alt"></i> ${site.city}, ${site.state}
-                                    </div>
-                                </div>
-                                <div style="text-align: right;">
-                                    <span class="badge severity-badge severity-${raw(escapeHtml(site.highest_severity.toLowerCase()))}">
-                                        ${site.highest_severity}
-                                    </span>
-                                    ${raw(tempHtml)}
-                                </div>
+    return html`
+        <div class="col-lg-6 col-12">
+            <a href="office-detail.html?office=${site.office_code}" class="text-decoration-none">
+                <div class="card office-card card-clickable ${raw(severityClass)}">
+                    <div class="office-card-header">
+                        <div>
+                            <h5 class="office-card-title text-dark">
+                                <strong>${site.office_code}</strong> - ${site.office_name}
+                            </h5>
+                            <div class="office-card-location">
+                                <i class="bi bi-geo-alt"></i> ${site.city}, ${site.state}
                             </div>
-                            <div class="office-card-body">
-                                <!-- Highest severity alert -->
-                                <div style="margin-bottom: 0.75rem;">
-                                    <strong class="text-dark">${highestAlert.advisory_type}</strong>
-                                    ${raw(highestAlert.vtec_action === 'NEW' ? '<span class="badge action-badge-new ms-2"><i class="bi bi-bell-fill"></i> NEW</span>' : '')}
-                                    ${raw(headlineText ? '<br><small class="text-muted" style="line-height: 1.3; display: inline-block; margin-top: 0.25rem;">' + escapeHtml(headlineText) + '</small>' : '')}
-                                    <br>
-                                    <small class="text-muted">
-                                        ${raw(highestAlert.expires ? 'Expires: ' + formatDate(highestAlert.expires) : '')}
-                                    </small>
-                                </div>
+                        </div>
+                        <div style="text-align: right;">
+                            <span
+                                class="badge severity-badge severity-${raw(
+                                    escapeHtml(site.highest_severity.toLowerCase())
+                                )}"
+                            >
+                                ${site.highest_severity}
+                            </span>
+                            ${raw(tempHtml)}
+                        </div>
+                    </div>
+                    <div class="office-card-body">
+                        <!-- Highest severity alert -->
+                        <div style="margin-bottom: 0.75rem;">
+                            <strong class="text-dark">${highestAlert.advisory_type}</strong>
+                            ${raw(
+                                highestAlert.vtec_action === 'NEW'
+                                    ? '<span class="badge action-badge-new ms-2"><i class="bi bi-bell-fill"></i> NEW</span>'
+                                    : ''
+                            )}
+                            ${raw(
+                                headlineText
+                                    ? '<br><small class="text-muted" style="line-height: 1.3; display: inline-block; margin-top: 0.25rem;">' +
+                                          escapeHtml(headlineText) +
+                                          '</small>'
+                                    : ''
+                            )}
+                            <br />
+                            <small class="text-muted">
+                                ${raw(highestAlert.expires ? 'Expires: ' + formatDate(highestAlert.expires) : '')}
+                            </small>
+                        </div>
 
-                                <!-- Alert summary -->
-                                <div class="alert-summary">
-                                    <div class="alert-stat">
-                                        <span class="alert-stat-icon">📊</span>
-                                        <span class="text-dark">
-                                            <span class="alert-stat-value">${site.unique_advisory_count}</span>
-                                            unique ${raw(site.unique_advisory_count === 1 ? 'alert' : 'alerts')}
-                                            ${raw(site.total_zone_count !== site.unique_advisory_count ?
-                                                `<span class="text-muted">(${site.total_zone_count} zones)</span>` : '')}
-                                        </span>
-                                    </div>
-                                    ${raw(site.new_count > 0 ? `
+                        <!-- Alert summary -->
+                        <div class="alert-summary">
+                            <div class="alert-stat">
+                                <span class="alert-stat-icon">📊</span>
+                                <span class="text-dark">
+                                    <span class="alert-stat-value">${site.unique_advisory_count}</span>
+                                    unique ${raw(site.unique_advisory_count === 1 ? 'alert' : 'alerts')}
+                                    ${raw(
+                                        site.total_zone_count !== site.unique_advisory_count
+                                            ? `<span class="text-muted">(${site.total_zone_count} zones)</span>`
+                                            : ''
+                                    )}
+                                </span>
+                            </div>
+                            ${raw(
+                                site.new_count > 0
+                                    ? `
                                     <div class="alert-stat">
                                         <span class="alert-stat-icon"><i class="bi bi-bell-fill"></i></span>
                                         <span class="text-dark"><span class="alert-stat-value">${site.new_count}</span> new</span>
                                     </div>
-                                    ` : '')}
-                                    ${raw(site.continued_count > 0 ? `
+                                    `
+                                    : ''
+                            )}
+                            ${raw(
+                                site.continued_count > 0
+                                    ? `
                                     <div class="alert-stat">
                                         <span class="alert-stat-icon"><i class="bi bi-arrow-repeat"></i></span>
                                         <span class="text-dark"><span class="alert-stat-value">${site.continued_count}</span> continued</span>
                                     </div>
-                                    ` : '')}
-                                </div>
-
-                                <!-- Advisory types -->
-                                <div class="advisory-type-list">
-                                    ${raw(site.type_groups.map(group => html`
-                                        <div class="advisory-type-item">
-                                            <span class="advisory-type-name">${group.type}</span>
-                                            <div class="advisory-type-meta">
-                                                ${raw(`<span class="badge ${getSeverityBadge(group.severity)}">${escapeHtml(group.severity)}</span>`)}
-                                                ${raw(group.zone_count > 1 ?
-                                                    `<span class="badge zone-badge zone-badge-multi" title="${group.zone_count} NWS zones">
-                                                        <i class="bi bi-layers"></i> ${group.zone_count} zones
-                                                    </span>` :
-                                                    `<span class="badge zone-badge">${escapeHtml(group.representative.source || 'NWS')}</span>`
-                                                )}
-                                            </div>
-                                        </div>
-                                    `).join(''))}
-                                </div>
-                            </div>
+                                    `
+                                    : ''
+                            )}
                         </div>
-                    </a>
+
+                        <!-- Advisory types -->
+                        <div class="advisory-type-list">
+                            ${raw(
+                                site.type_groups
+                                    .map(
+                                        (group) => html`
+                                            <div class="advisory-type-item">
+                                                <span class="advisory-type-name">${group.type}</span>
+                                                <div class="advisory-type-meta">
+                                                    ${raw(
+                                                        `<span class="badge ${getSeverityBadge(group.severity)}">${escapeHtml(group.severity)}</span>`
+                                                    )}
+                                                    ${raw(
+                                                        group.zone_count > 1
+                                                            ? `<span class="badge zone-badge zone-badge-multi" title="${group.zone_count} NWS zones">
+                                                        <i class="bi bi-layers"></i> ${group.zone_count} zones
+                                                    </span>`
+                                                            : `<span class="badge zone-badge">${escapeHtml(group.representative.source || 'NWS')}</span>`
+                                                    )}
+                                                </div>
+                                            </div>
+                                        `
+                                    )
+                                    .join('')
+                            )}
+                        </div>
+                    </div>
                 </div>
-            `;
-        }
+            </a>
+        </div>
+    `;
+}
 
-        /**
-         * Switch between card and table views.
-         * Toggles active state on the view-selector buttons, shows/hides the
-         * corresponding container elements, and triggers a full re-render so the
-         * new view reflects the current filter state immediately.
-         * Both containers remain in the DOM at all times (toggled via d-none) to
-         * avoid losing scroll position on the inactive container when switching back.
-         *
-         * @param {'card'|'table'} view - Target view identifier
-         * @returns {void}
-         */
-        function switchView(view) {
-            currentView = view;
+/**
+ * Switch between card and table views.
+ * Toggles active state on the view-selector buttons, shows/hides the
+ * corresponding container elements, and triggers a full re-render so the
+ * new view reflects the current filter state immediately.
+ * Both containers remain in the DOM at all times (toggled via d-none) to
+ * avoid losing scroll position on the inactive container when switching back.
+ *
+ * @param {'card'|'table'} view - Target view identifier
+ * @returns {void}
+ */
+function switchView(view) {
+    currentView = view;
 
-            if (view === 'card') {
-                document.getElementById('cardViewBtn').classList.add('active');
-                document.getElementById('tableViewBtn').classList.remove('active');
-                document.getElementById('cardViewContainer').classList.remove('d-none');
-                document.getElementById('tableViewContainer').classList.add('d-none');
-            } else {
-                document.getElementById('cardViewBtn').classList.remove('active');
-                document.getElementById('tableViewBtn').classList.add('active');
-                document.getElementById('cardViewContainer').classList.add('d-none');
-                document.getElementById('tableViewContainer').classList.remove('d-none');
-            }
+    if (view === 'card') {
+        document.getElementById('cardViewBtn').classList.add('active');
+        document.getElementById('tableViewBtn').classList.remove('active');
+        document.getElementById('cardViewContainer').classList.remove('d-none');
+        document.getElementById('tableViewContainer').classList.add('d-none');
+    } else {
+        document.getElementById('cardViewBtn').classList.remove('active');
+        document.getElementById('tableViewBtn').classList.add('active');
+        document.getElementById('cardViewContainer').classList.add('d-none');
+        document.getElementById('tableViewContainer').classList.remove('d-none');
+    }
 
-            renderAll();
-        }
+    renderAll();
+}
 
-        /**
-         * Reset all filter controls to their "show everything" state and re-render.
-         * Called by the "Show All Alerts" button in the filter-warning banner so
-         * operators can quickly clear accidental over-filtering with a single click.
-         *
-         * @returns {void}
-         */
-        function showAllAlerts() {
-            document.getElementById('searchBox').value = '';
-            document.getElementById('alertTypeFilter').value = 'FULL';
-            document.getElementById('stateFilter').value = '';
-            document.getElementById('severityFilter').value = '';
-            renderAll();
-        }
+/**
+ * Reset all filter controls to their "show everything" state and re-render.
+ * Called by the "Show All Alerts" button in the filter-warning banner so
+ * operators can quickly clear accidental over-filtering with a single click.
+ *
+ * @returns {void}
+ */
+function showAllAlerts() {
+    document.getElementById('searchBox').value = '';
+    document.getElementById('alertTypeFilter').value = 'FULL';
+    document.getElementById('stateFilter').value = '';
+    document.getElementById('severityFilter').value = '';
+    renderAll();
+}
 
-        // Event listeners
-        // 300ms debounce on the search box: balances immediate-feeling response
-        // against avoiding a render on every keystroke during fast typing.
-        document.getElementById('searchBox').addEventListener('input', debounce(renderAll, 300));
-        document.getElementById('alertTypeFilter').addEventListener('change', renderAll);
-        document.getElementById('stateFilter').addEventListener('change', renderAll);
-        document.getElementById('severityFilter').addEventListener('change', renderAll);
-        document.getElementById('dedupToggle').addEventListener('change', renderAll);
-        document.getElementById('cardViewBtn').addEventListener('click', () => switchView('card'));
-        document.getElementById('tableViewBtn').addEventListener('click', () => switchView('table'));
+// Event listeners
+// 300ms debounce on the search box: balances immediate-feeling response
+// against avoiding a render on every keystroke during fast typing.
+document.getElementById('searchBox').addEventListener('input', debounce(renderAll, 300));
+document.getElementById('alertTypeFilter').addEventListener('change', renderAll);
+document.getElementById('stateFilter').addEventListener('change', renderAll);
+document.getElementById('severityFilter').addEventListener('change', renderAll);
+document.getElementById('dedupToggle').addEventListener('change', renderAll);
+document.getElementById('cardViewBtn').addEventListener('click', () => switchView('card'));
+document.getElementById('tableViewBtn').addEventListener('click', () => switchView('table'));
 
-        /**
-         * Read URL query parameters and pre-populate filter controls accordingly.
-         * Supports ?severity= so that links from the dashboard's severity badges
-         * open the advisories page pre-filtered to the clicked severity level.
-         * Called after advisories are loaded so the filter applies to real data.
-         *
-         * @returns {void}
-         */
-        function applyURLParameters() {
-            const urlParams = new URLSearchParams(window.location.search);
-            const severityParam = urlParams.get('severity');
+/**
+ * Read URL query parameters and pre-populate filter controls accordingly.
+ * Supports ?severity= so that links from the dashboard's severity badges
+ * open the advisories page pre-filtered to the clicked severity level.
+ * Called after advisories are loaded so the filter applies to real data.
+ *
+ * @returns {void}
+ */
+function applyURLParameters() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const severityParam = urlParams.get('severity');
 
-            if (severityParam) {
-                // Auto-select severity dropdown with value from URL
-                const severityFilter = document.getElementById('severityFilter');
-                severityFilter.value = severityParam;
-                // Trigger filtering
-                renderAll();
-            }
-        }
+    if (severityParam) {
+        // Auto-select severity dropdown with value from URL
+        const severityFilter = document.getElementById('severityFilter');
+        severityFilter.value = severityParam;
+        // Trigger filtering
+        renderAll();
+    }
+}
 
-        // Initialize: Load filter configs then load advisories
-        AlertFilters.init().then(() => {
-            loadAdvisories();
-            // Apply URL parameters after advisories are loaded
-            setTimeout(() => applyURLParameters(), 100);
-        });
+// Initialize: Load filter configs then load advisories
+AlertFilters.init().then(() => {
+    loadAdvisories();
+    // Apply URL parameters after advisories are loaded
+    setTimeout(() => applyURLParameters(), 100);
+});

--- a/frontend/js/page-filters.js
+++ b/frontend/js/page-filters.js
@@ -1,415 +1,428 @@
-        /**
-         * page-filters.js
-         * Filter settings page — lets users configure which of the 94 NOAA alert
-         * types to include; saves preferences to localStorage.
-         *
-         * Key responsibilities:
-         *   - Fetches the full NOAA alert-type taxonomy (grouped by impact level)
-         *     and the available filter presets from the backend API
-         *   - Loads existing preferences from localStorage (STORAGE_KEY) and
-         *     falls back to the DEFAULT_PRESET when no saved state is found
-         *   - Renders a toggle card for each alert type, grouped by impact level
-         *     (CRITICAL, HIGH, MODERATE, LOW, INFO)
-         *   - Supports preset application (Standard, Minimal, Full, Custom) and
-         *     per-level bulk enable/disable
-         *   - Persists the current toggle state to localStorage on save; the
-         *     AlertFilters utility reads this key on all other pages
-         *
-         * State variables:
-         *   alertTypesByLevel - Object keyed by impact level; value is string[] of types
-         *   filterPresets     - Named preset configs fetched from the backend
-         *   currentFilters    - Map of alertType → true|undefined (undefined = disabled)
-         *
-         * External dependencies (globals):
-         *   API_BASE_URL, html, raw, escapeHtml, renderEmptyHtml, renderErrorHtml
-         */
+/**
+ * page-filters.js
+ * Filter settings page — lets users configure which of the 94 NOAA alert
+ * types to include; saves preferences to localStorage.
+ *
+ * Key responsibilities:
+ *   - Fetches the full NOAA alert-type taxonomy (grouped by impact level)
+ *     and the available filter presets from the backend API
+ *   - Loads existing preferences from localStorage (STORAGE_KEY) and
+ *     falls back to the DEFAULT_PRESET when no saved state is found
+ *   - Renders a toggle card for each alert type, grouped by impact level
+ *     (CRITICAL, HIGH, MODERATE, LOW, INFO)
+ *   - Supports preset application (Standard, Minimal, Full, Custom) and
+ *     per-level bulk enable/disable
+ *   - Persists the current toggle state to localStorage on save; the
+ *     AlertFilters utility reads this key on all other pages
+ *
+ * State variables:
+ *   alertTypesByLevel - Object keyed by impact level; value is string[] of types
+ *   filterPresets     - Named preset configs fetched from the backend
+ *   currentFilters    - Map of alertType → true|undefined (undefined = disabled)
+ *
+ * External dependencies (globals):
+ *   API_BASE_URL, html, raw, escapeHtml, renderEmptyHtml, renderErrorHtml
+ */
 
-        const STORAGE_KEY = 'stormScout_alertFilters';
-        const DEFAULT_PRESET = 'CUSTOM';
+const STORAGE_KEY = 'stormScout_alertFilters';
+const DEFAULT_PRESET = 'CUSTOM';
 
-        let alertTypesByLevel = {};
-        let filterPresets = {};
-        let currentFilters = {};
+let alertTypesByLevel = {};
+let filterPresets = {};
+let currentFilters = {};
 
-        // Alert type descriptions
-        const ALERT_DESCRIPTIONS = {
-            // CRITICAL
-            'Tornado Warning': 'A tornado has been sighted or indicated by radar. Take shelter immediately.',
-            'Hurricane Warning': 'Hurricane conditions expected within 36 hours. Complete preparations now.',
-            'Flash Flood Warning': 'Flash flooding is occurring or imminent. Move to higher ground immediately.',
-            'Severe Thunderstorm Warning': 'Severe thunderstorm producing damaging winds and/or large hail.',
-            'Blizzard Warning': 'Severe winter storm with sustained winds 35+ mph and falling/blowing snow.',
-            'Tsunami Warning': 'Tsunami is imminent or occurring. Evacuate coastal areas immediately.',
+// Alert type descriptions
+const ALERT_DESCRIPTIONS = {
+    // CRITICAL
+    'Tornado Warning': 'A tornado has been sighted or indicated by radar. Take shelter immediately.',
+    'Hurricane Warning': 'Hurricane conditions expected within 36 hours. Complete preparations now.',
+    'Flash Flood Warning': 'Flash flooding is occurring or imminent. Move to higher ground immediately.',
+    'Severe Thunderstorm Warning': 'Severe thunderstorm producing damaging winds and/or large hail.',
+    'Blizzard Warning': 'Severe winter storm with sustained winds 35+ mph and falling/blowing snow.',
+    'Tsunami Warning': 'Tsunami is imminent or occurring. Evacuate coastal areas immediately.',
 
-            // HIGH
-            'Winter Storm Warning': 'Significant winter weather expected. Prepare for hazardous conditions.',
-            'Flood Warning': 'Flooding is occurring or imminent. Be prepared to evacuate.',
-            'High Wind Warning': 'Sustained winds 40+ mph or gusts 58+ mph expected.',
-            'Tornado Watch': 'Conditions favorable for tornado development. Monitor weather closely.',
-            'Tropical Storm Warning': 'Tropical storm conditions expected within 36 hours.',
+    // HIGH
+    'Winter Storm Warning': 'Significant winter weather expected. Prepare for hazardous conditions.',
+    'Flood Warning': 'Flooding is occurring or imminent. Be prepared to evacuate.',
+    'High Wind Warning': 'Sustained winds 40+ mph or gusts 58+ mph expected.',
+    'Tornado Watch': 'Conditions favorable for tornado development. Monitor weather closely.',
+    'Tropical Storm Warning': 'Tropical storm conditions expected within 36 hours.',
 
-            // MODERATE
-            'Winter Weather Advisory': 'Winter weather conditions may cause travel difficulties.',
-            'Wind Advisory': 'Sustained winds 30-40 mph or gusts 45-57 mph expected.',
-            'Heat Advisory': 'Heat index values may cause heat-related illness.',
-            'Dense Fog Advisory': 'Dense fog reducing visibility to 1/4 mile or less.',
+    // MODERATE
+    'Winter Weather Advisory': 'Winter weather conditions may cause travel difficulties.',
+    'Wind Advisory': 'Sustained winds 30-40 mph or gusts 45-57 mph expected.',
+    'Heat Advisory': 'Heat index values may cause heat-related illness.',
+    'Dense Fog Advisory': 'Dense fog reducing visibility to 1/4 mile or less.',
 
-            // LOW
-            'Small Craft Advisory': 'Hazardous conditions for small boats.',
-            'Rip Current Statement': 'Dangerous rip currents present at beaches.',
-            'Beach Hazards Statement': 'Hazardous conditions at beaches.',
-            'Cold Weather Advisory': 'Cold temperatures may cause health concerns.',
+    // LOW
+    'Small Craft Advisory': 'Hazardous conditions for small boats.',
+    'Rip Current Statement': 'Dangerous rip currents present at beaches.',
+    'Beach Hazards Statement': 'Hazardous conditions at beaches.',
+    'Cold Weather Advisory': 'Cold temperatures may cause health concerns.',
 
-            // INFO
-            'Special Weather Statement': 'Non-warning informational statement about weather.',
-            'Marine Weather Statement': 'Informational statement for marine interests.',
-            'Hazardous Weather Outlook': 'Potential for hazardous weather in the coming days.'
-        };
+    // INFO
+    'Special Weather Statement': 'Non-warning informational statement about weather.',
+    'Marine Weather Statement': 'Informational statement for marine interests.',
+    'Hazardous Weather Outlook': 'Potential for hazardous weather in the coming days.'
+};
 
-        // Impact level colors
-        const IMPACT_COLORS = {
-            'CRITICAL': 'danger',
-            'HIGH': 'warning',
-            'MODERATE': 'info',
-            'LOW': 'secondary',
-            'INFO': 'light'
-        };
+// Impact level colors
+const IMPACT_COLORS = {
+    CRITICAL: 'danger',
+    HIGH: 'warning',
+    MODERATE: 'info',
+    LOW: 'secondary',
+    INFO: 'light'
+};
 
-        /**
-         * Fetch alert-type taxonomy and filter presets from the API, then
-         * restore saved preferences and render the full settings page.
-         * Both fetch calls are sequential (presets depend on knowing the type list
-         * to validate categories) and failures show an inline error.
-         *
-         * @returns {Promise<void>}
-         */
-        async function loadData() {
-            try {
-                // Load alert types
-                const typesResponse = await fetch(`${API_BASE_URL}/filters/types/all`);
-                const typesData = await typesResponse.json();
-                alertTypesByLevel = typesData.data;
+/**
+ * Fetch alert-type taxonomy and filter presets from the API, then
+ * restore saved preferences and render the full settings page.
+ * Both fetch calls are sequential (presets depend on knowing the type list
+ * to validate categories) and failures show an inline error.
+ *
+ * @returns {Promise<void>}
+ */
+async function loadData() {
+    try {
+        // Load alert types
+        const typesResponse = await fetch(`${API_BASE_URL}/filters/types/all`);
+        const typesData = await typesResponse.json();
+        alertTypesByLevel = typesData.data;
 
-                // Load presets
-                const presetsResponse = await fetch(`${API_BASE_URL}/filters`);
-                const presetsData = await presetsResponse.json();
-                filterPresets = presetsData.data;
+        // Load presets
+        const presetsResponse = await fetch(`${API_BASE_URL}/filters`);
+        const presetsData = await presetsResponse.json();
+        filterPresets = presetsData.data;
 
-                // Load saved preferences or use defaults
-                loadPreferences();
+        // Load saved preferences or use defaults
+        loadPreferences();
 
-                // Render the page
-                renderAlertTypes();
-                updateStatus();
+        // Render the page
+        renderAlertTypes();
+        updateStatus();
+    } catch (error) {
+        console.error('Failed to load data:', error);
+        document.getElementById('alertTypesContainer').innerHTML = renderErrorHtml(
+            'Failed to load alert types. Please refresh the page.'
+        );
+    }
+}
 
-            } catch (error) {
-                console.error('Failed to load data:', error);
-                document.getElementById('alertTypesContainer').innerHTML =
-                    renderErrorHtml('Failed to load alert types. Please refresh the page.');
-            }
-        }
+/**
+ * Restore saved filter preferences from localStorage into currentFilters.
+ * Falls back to the DEFAULT_PRESET when no saved state exists (e.g. first visit).
+ * The save=false argument prevents applyPreset from immediately re-saving,
+ * which would overwrite existing preferences before the user has a chance to
+ * review them.
+ *
+ * @returns {void}
+ */
+function loadPreferences() {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) {
+        currentFilters = JSON.parse(saved);
+    } else {
+        // Use default preset
+        applyPreset(DEFAULT_PRESET, false);
+    }
+}
 
-        /**
-         * Restore saved filter preferences from localStorage into currentFilters.
-         * Falls back to the DEFAULT_PRESET when no saved state exists (e.g. first visit).
-         * The save=false argument prevents applyPreset from immediately re-saving,
-         * which would overwrite existing preferences before the user has a chance to
-         * review them.
-         *
-         * @returns {void}
-         */
-        function loadPreferences() {
-            const saved = localStorage.getItem(STORAGE_KEY);
-            if (saved) {
-                currentFilters = JSON.parse(saved);
-            } else {
-                // Use default preset
-                applyPreset(DEFAULT_PRESET, false);
-            }
-        }
+/**
+ * Persist the current toggle state to localStorage and show a 2-second
+ * success confirmation in the status element.
+ * Saving to localStorage means the preference is instantly available to
+ * AlertFilters on all other pages without a round-trip to the server.
+ *
+ * @returns {void}
+ */
+function savePreferences() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(currentFilters));
 
-        /**
-         * Persist the current toggle state to localStorage and show a 2-second
-         * success confirmation in the status element.
-         * Saving to localStorage means the preference is instantly available to
-         * AlertFilters on all other pages without a round-trip to the server.
-         *
-         * @returns {void}
-         */
-        function savePreferences() {
-            localStorage.setItem(STORAGE_KEY, JSON.stringify(currentFilters));
+    // Show success message
+    const statusEl = document.getElementById('activeFilterStatus');
+    const originalText = statusEl.textContent;
+    statusEl.textContent = '✓ Preferences saved!';
+    statusEl.parentElement.classList.add('alert-success');
+    statusEl.parentElement.classList.remove('alert-info');
 
-            // Show success message
-            const statusEl = document.getElementById('activeFilterStatus');
-            const originalText = statusEl.textContent;
-            statusEl.textContent = '✓ Preferences saved!';
-            statusEl.parentElement.classList.add('alert-success');
-            statusEl.parentElement.classList.remove('alert-info');
+    setTimeout(() => {
+        statusEl.textContent = originalText;
+        statusEl.parentElement.classList.remove('alert-success');
+        statusEl.parentElement.classList.add('alert-info');
+    }, 2000);
+}
 
-            setTimeout(() => {
-                statusEl.textContent = originalText;
-                statusEl.parentElement.classList.remove('alert-success');
-                statusEl.parentElement.classList.add('alert-info');
-            }, 2000);
-        }
+/**
+ * Apply a named filter preset to currentFilters and re-render.
+ * Preset application logic:
+ *   1. Reset currentFilters to an empty object (all disabled)
+ *   2. For each impact level in the preset's includeCategories, enable every
+ *      alert type in that level unless it appears in excludeTypes
+ * This additive model (enable-then-exclude) keeps preset definitions concise
+ * since most presets include whole levels with only a few exceptions.
+ *
+ * @param {string}  presetName - Key in filterPresets (e.g. 'STANDARD', 'FULL')
+ * @param {boolean} [save=true] - Whether to immediately persist to localStorage
+ * @returns {void}
+ */
+function applyPreset(presetName, save = true) {
+    const preset = filterPresets[presetName];
+    if (!preset) return;
 
-        /**
-         * Apply a named filter preset to currentFilters and re-render.
-         * Preset application logic:
-         *   1. Reset currentFilters to an empty object (all disabled)
-         *   2. For each impact level in the preset's includeCategories, enable every
-         *      alert type in that level unless it appears in excludeTypes
-         * This additive model (enable-then-exclude) keeps preset definitions concise
-         * since most presets include whole levels with only a few exceptions.
-         *
-         * @param {string}  presetName - Key in filterPresets (e.g. 'STANDARD', 'FULL')
-         * @param {boolean} [save=true] - Whether to immediately persist to localStorage
-         * @returns {void}
-         */
-        function applyPreset(presetName, save = true) {
-            const preset = filterPresets[presetName];
-            if (!preset) return;
+    currentFilters = {};
 
-            currentFilters = {};
-
-            // Enable all alert types in included categories
-            for (const [level, types] of Object.entries(alertTypesByLevel)) {
-                if (preset.includeCategories.includes(level)) {
-                    types.forEach(type => {
-                        // Check if explicitly excluded
-                        if (!preset.excludeTypes || !preset.excludeTypes.includes(type)) {
-                            currentFilters[type] = true;
-                        }
-                    });
+    // Enable all alert types in included categories
+    for (const [level, types] of Object.entries(alertTypesByLevel)) {
+        if (preset.includeCategories.includes(level)) {
+            types.forEach((type) => {
+                // Check if explicitly excluded
+                if (!preset.excludeTypes || !preset.excludeTypes.includes(type)) {
+                    currentFilters[type] = true;
                 }
-            }
-
-            renderAlertTypes();
-            updateStatus();
-
-            if (save) {
-                savePreferences();
-            }
-        }
-
-        /**
-         * Prompt the user for confirmation, then reset to the DEFAULT_PRESET.
-         * The confirmation dialog prevents accidental resets of carefully customised
-         * configurations.
-         *
-         * @returns {void}
-         */
-        function resetToDefaults() {
-            if (confirm('Reset to default filter settings (Office Default)?')) {
-                applyPreset(DEFAULT_PRESET, true);
-            }
-        }
-
-        /**
-         * Toggle a single alert type between enabled (true) and disabled (undefined).
-         * Undefined rather than false is used for the disabled state to keep the stored
-         * object sparse — only enabled types are written, matching how AlertFilters
-         * reads preferences on other pages.
-         * The DOM card is updated immediately (without a full re-render) for instant
-         * visual feedback.
-         *
-         * @param {string} alertType - NOAA alert type string to toggle
-         * @returns {void}
-         */
-        function toggleAlertType(alertType) {
-            // Toggle state
-            const newState = currentFilters[alertType] === true ? undefined : true;
-            currentFilters[alertType] = newState;
-
-            // Update DOM immediately for instant visual feedback
-            const elementId = `alert_${alertType.replace(/\s+/g, '_')}`;
-            const checkbox = document.getElementById(elementId);
-
-            if (checkbox) {
-                const card = checkbox.closest('.alert-type-card');
-
-                if (card) {
-                    if (newState === true) {
-                        // Enable: remove disabled class, check the box
-                        card.classList.remove('disabled');
-                        checkbox.checked = true;
-                    } else {
-                        // Disable: add disabled class, uncheck the box
-                        card.classList.add('disabled');
-                        checkbox.checked = false;
-                    }
-                }
-            }
-
-            updateStatus();
-        }
-
-        /**
-         * Re-render the full alert-type grid from alertTypesByLevel and currentFilters.
-         * Each impact level gets a section heading with bulk enable/disable buttons,
-         * followed by one toggle card per alert type.
-         *
-         * @returns {void}
-         */
-        function renderAlertTypes() {
-            const container = document.getElementById('alertTypesContainer');
-            let htmlContent = '';
-
-            for (const [level, types] of Object.entries(alertTypesByLevel)) {
-                const color = IMPACT_COLORS[level];
-                const levelName = level.charAt(0) + level.slice(1).toLowerCase();
-                const safeLevel = escapeHtml(level);
-
-                htmlContent += html`
-                    <div class="row mb-4">
-                        <div class="col-12">
-                            <h4 class="border-bottom pb-2">
-                                <span class="badge bg-${raw(color)} impact-badge">${levelName}</span>
-                                ${level} Impact Alerts
-                                <button class="btn btn-sm btn-outline-secondary ms-2" data-toggle-level="${safeLevel}" data-enable="true">
-                                    Enable All
-                                </button>
-                                <button class="btn btn-sm btn-outline-secondary" data-toggle-level="${safeLevel}" data-enable="false">
-                                    Disable All
-                                </button>
-                            </h4>
-                        </div>
-                `;
-
-                types.forEach(type => {
-                    const isEnabled = currentFilters[type] === true;
-                    const description = ALERT_DESCRIPTIONS[type] || 'Official NOAA weather alert type.';
-                    const safeType = escapeHtml(type);
-                    const safeTypeId = escapeHtml(type.replace(/\s+/g, '_'));
-
-                    htmlContent += html`
-                        <div class="col-md-6 col-lg-4 mb-3">
-                            <div class="card alert-type-card ${raw(!isEnabled ? 'disabled' : '')}">
-                                <div class="card-body">
-                                    <div class="form-check form-switch">
-                                        <input class="form-check-input" type="checkbox"
-                                               id="alert_${safeTypeId}"
-                                               data-alert-type="${safeType}"
-                                               ${raw(isEnabled ? 'checked' : '')}>
-                                        <label class="form-check-label" for="alert_${safeTypeId}">
-                                            <strong>${type}</strong>
-                                        </label>
-                                    </div>
-                                    <p class="text-muted small mb-0 mt-2">${description}</p>
-                                </div>
-                            </div>
-                        </div>
-                    `;
-                });
-
-                htmlContent += '</div>';
-            }
-
-            container.innerHTML = htmlContent;
-        }
-
-        /**
-         * Bulk-enable or bulk-disable all alert types within an impact level.
-         *
-         * @param {string}  level  - Impact level key (e.g. 'CRITICAL', 'HIGH')
-         * @param {boolean} enable - True to enable all types; false to disable
-         * @returns {void}
-         */
-        function toggleLevel(level, enable) {
-            const types = alertTypesByLevel[level];
-            if (!types) return;
-
-            types.forEach(type => {
-                currentFilters[type] = enable;
             });
-
-            renderAlertTypes();
-            updateStatus();
         }
+    }
 
-        /**
-         * Refresh the enabled-count display and detect whether the current
-         * filter configuration exactly matches a known preset.
-         * The preset label ("Standard", "Full", etc.) is shown in the status bar
-         * so users know which preset is active without opening the dropdown.
-         *
-         * @returns {void}
-         */
-        function updateStatus() {
-            const totalTypes = Object.values(alertTypesByLevel).flat().length;
-            const enabledTypes = Object.values(currentFilters).filter(v => v === true).length;
+    renderAlertTypes();
+    updateStatus();
 
-            document.getElementById('enabledCount').textContent = enabledTypes;
-            document.getElementById('totalCount').textContent = totalTypes;
+    if (save) {
+        savePreferences();
+    }
+}
 
-            // Determine which preset matches current config (if any)
-            let matchingPreset = 'Custom';
-            for (const [name, preset] of Object.entries(filterPresets)) {
-                if (isPresetMatch(preset)) {
-                    matchingPreset = preset.name;
-                    break;
-                }
+/**
+ * Prompt the user for confirmation, then reset to the DEFAULT_PRESET.
+ * The confirmation dialog prevents accidental resets of carefully customised
+ * configurations.
+ *
+ * @returns {void}
+ */
+function resetToDefaults() {
+    if (confirm('Reset to default filter settings (Office Default)?')) {
+        applyPreset(DEFAULT_PRESET, true);
+    }
+}
+
+/**
+ * Toggle a single alert type between enabled (true) and disabled (undefined).
+ * Undefined rather than false is used for the disabled state to keep the stored
+ * object sparse — only enabled types are written, matching how AlertFilters
+ * reads preferences on other pages.
+ * The DOM card is updated immediately (without a full re-render) for instant
+ * visual feedback.
+ *
+ * @param {string} alertType - NOAA alert type string to toggle
+ * @returns {void}
+ */
+function toggleAlertType(alertType) {
+    // Toggle state
+    const newState = currentFilters[alertType] === true ? undefined : true;
+    currentFilters[alertType] = newState;
+
+    // Update DOM immediately for instant visual feedback
+    const elementId = `alert_${alertType.replace(/\s+/g, '_')}`;
+    const checkbox = document.getElementById(elementId);
+
+    if (checkbox) {
+        const card = checkbox.closest('.alert-type-card');
+
+        if (card) {
+            if (newState === true) {
+                // Enable: remove disabled class, check the box
+                card.classList.remove('disabled');
+                checkbox.checked = true;
+            } else {
+                // Disable: add disabled class, uncheck the box
+                card.classList.add('disabled');
+                checkbox.checked = false;
             }
-
-            document.getElementById('activeFilterStatus').textContent = matchingPreset;
         }
+    }
 
-        /**
-         * Test whether the current currentFilters state exactly matches a preset.
-         * Iterates every known alert type and compares its expected state (derived
-         * from the preset's includeCategories and excludeTypes) against the actual
-         * state in currentFilters. A single mismatch returns false.
-         *
-         * @param {Object} preset - Preset config object with includeCategories and
-         *                          optional excludeTypes arrays
-         * @returns {boolean} True if currentFilters matches the preset exactly
-         */
-        function isPresetMatch(preset) {
-            const enabledTypes = Object.entries(currentFilters)
-                .filter(([type, enabled]) => enabled === true)
-                .map(([type]) => type);
+    updateStatus();
+}
 
-            for (const [level, types] of Object.entries(alertTypesByLevel)) {
-                for (const type of types) {
-                    const shouldBeEnabled = preset.includeCategories.includes(level) &&
-                                          (!preset.excludeTypes || !preset.excludeTypes.includes(type));
-                    const isEnabled = currentFilters[type] === true;
+/**
+ * Re-render the full alert-type grid from alertTypesByLevel and currentFilters.
+ * Each impact level gets a section heading with bulk enable/disable buttons,
+ * followed by one toggle card per alert type.
+ *
+ * @returns {void}
+ */
+function renderAlertTypes() {
+    const container = document.getElementById('alertTypesContainer');
+    let htmlContent = '';
 
-                    if (shouldBeEnabled !== isEnabled) {
-                        return false;
-                    }
-                }
-            }
+    for (const [level, types] of Object.entries(alertTypesByLevel)) {
+        const color = IMPACT_COLORS[level];
+        const levelName = level.charAt(0) + level.slice(1).toLowerCase();
+        const safeLevel = escapeHtml(level);
 
-            return true;
-        }
+        htmlContent += html`
+            <div class="row mb-4">
+                <div class="col-12">
+                    <h4 class="border-bottom pb-2">
+                        <span class="badge bg-${raw(color)} impact-badge">${levelName}</span>
+                        ${level} Impact Alerts
+                        <button
+                            class="btn btn-sm btn-outline-secondary ms-2"
+                            data-toggle-level="${safeLevel}"
+                            data-enable="true"
+                        >
+                            Enable All
+                        </button>
+                        <button
+                            class="btn btn-sm btn-outline-secondary"
+                            data-toggle-level="${safeLevel}"
+                            data-enable="false"
+                        >
+                            Disable All
+                        </button>
+                    </h4>
+                </div>
+            </div>
+        `;
 
-        // Event delegation for dynamically generated elements
-        document.addEventListener('click', function(e) {
-            // Preset buttons
-            if (e.target.closest('[data-preset]')) {
-                const preset = e.target.closest('[data-preset]').dataset.preset;
-                applyPreset(preset);
-            }
-            // Toggle level buttons
-            if (e.target.closest('[data-toggle-level]')) {
-                const btn = e.target.closest('[data-toggle-level]');
-                const level = btn.dataset.toggleLevel;
-                const enable = btn.dataset.enable === 'true';
-                toggleLevel(level, enable);
-            }
+        types.forEach((type) => {
+            const isEnabled = currentFilters[type] === true;
+            const description = ALERT_DESCRIPTIONS[type] || 'Official NOAA weather alert type.';
+            const safeType = escapeHtml(type);
+            const safeTypeId = escapeHtml(type.replace(/\s+/g, '_'));
+
+            htmlContent += html`
+                <div class="col-md-6 col-lg-4 mb-3">
+                    <div class="card alert-type-card ${raw(!isEnabled ? 'disabled' : '')}">
+                        <div class="card-body">
+                            <div class="form-check form-switch">
+                                <input
+                                    class="form-check-input"
+                                    type="checkbox"
+                                    id="alert_${safeTypeId}"
+                                    data-alert-type="${safeType}"
+                                    ${raw(isEnabled ? 'checked' : '')}
+                                />
+                                <label class="form-check-label" for="alert_${safeTypeId}">
+                                    <strong>${type}</strong>
+                                </label>
+                            </div>
+                            <p class="text-muted small mb-0 mt-2">${description}</p>
+                        </div>
+                    </div>
+                </div>
+            `;
         });
 
-        document.addEventListener('change', function(e) {
-            // Alert type toggles
-            if (e.target.dataset.alertType) {
-                toggleAlertType(e.target.dataset.alertType);
+        htmlContent += '</div>';
+    }
+
+    container.innerHTML = htmlContent;
+}
+
+/**
+ * Bulk-enable or bulk-disable all alert types within an impact level.
+ *
+ * @param {string}  level  - Impact level key (e.g. 'CRITICAL', 'HIGH')
+ * @param {boolean} enable - True to enable all types; false to disable
+ * @returns {void}
+ */
+function toggleLevel(level, enable) {
+    const types = alertTypesByLevel[level];
+    if (!types) return;
+
+    types.forEach((type) => {
+        currentFilters[type] = enable;
+    });
+
+    renderAlertTypes();
+    updateStatus();
+}
+
+/**
+ * Refresh the enabled-count display and detect whether the current
+ * filter configuration exactly matches a known preset.
+ * The preset label ("Standard", "Full", etc.) is shown in the status bar
+ * so users know which preset is active without opening the dropdown.
+ *
+ * @returns {void}
+ */
+function updateStatus() {
+    const totalTypes = Object.values(alertTypesByLevel).flat().length;
+    const enabledTypes = Object.values(currentFilters).filter((v) => v === true).length;
+
+    document.getElementById('enabledCount').textContent = enabledTypes;
+    document.getElementById('totalCount').textContent = totalTypes;
+
+    // Determine which preset matches current config (if any)
+    let matchingPreset = 'Custom';
+    for (const [name, preset] of Object.entries(filterPresets)) {
+        if (isPresetMatch(preset)) {
+            matchingPreset = preset.name;
+            break;
+        }
+    }
+
+    document.getElementById('activeFilterStatus').textContent = matchingPreset;
+}
+
+/**
+ * Test whether the current currentFilters state exactly matches a preset.
+ * Iterates every known alert type and compares its expected state (derived
+ * from the preset's includeCategories and excludeTypes) against the actual
+ * state in currentFilters. A single mismatch returns false.
+ *
+ * @param {Object} preset - Preset config object with includeCategories and
+ *                          optional excludeTypes arrays
+ * @returns {boolean} True if currentFilters matches the preset exactly
+ */
+function isPresetMatch(preset) {
+    const enabledTypes = Object.entries(currentFilters)
+        .filter(([type, enabled]) => enabled === true)
+        .map(([type]) => type);
+
+    for (const [level, types] of Object.entries(alertTypesByLevel)) {
+        for (const type of types) {
+            const shouldBeEnabled =
+                preset.includeCategories.includes(level) &&
+                (!preset.excludeTypes || !preset.excludeTypes.includes(type));
+            const isEnabled = currentFilters[type] === true;
+
+            if (shouldBeEnabled !== isEnabled) {
+                return false;
             }
-        });
+        }
+    }
 
-        // Static button event listeners
-        document.getElementById('resetDefaultsBtn').addEventListener('click', resetToDefaults);
-        document.getElementById('savePrefsBtn').addEventListener('click', savePreferences);
+    return true;
+}
 
-        // Initialize
-        loadData();
+// Event delegation for dynamically generated elements
+document.addEventListener('click', function (e) {
+    // Preset buttons
+    if (e.target.closest('[data-preset]')) {
+        const preset = e.target.closest('[data-preset]').dataset.preset;
+        applyPreset(preset);
+    }
+    // Toggle level buttons
+    if (e.target.closest('[data-toggle-level]')) {
+        const btn = e.target.closest('[data-toggle-level]');
+        const level = btn.dataset.toggleLevel;
+        const enable = btn.dataset.enable === 'true';
+        toggleLevel(level, enable);
+    }
+});
+
+document.addEventListener('change', function (e) {
+    // Alert type toggles
+    if (e.target.dataset.alertType) {
+        toggleAlertType(e.target.dataset.alertType);
+    }
+});
+
+// Static button event listeners
+document.getElementById('resetDefaultsBtn').addEventListener('click', resetToDefaults);
+document.getElementById('savePrefsBtn').addEventListener('click', savePreferences);
+
+// Initialize
+loadData();

--- a/frontend/js/page-index.js
+++ b/frontend/js/page-index.js
@@ -1,410 +1,511 @@
-        /**
-         * page-index.js
-         * Dashboard index page — loads overview stats, impacted offices, top advisories,
-         * and weather observations; drives the update countdown timer.
-         *
-         * Key responsibilities:
-         *   - Fetches overview stats, all active advisories, and weather observations
-         *     in parallel on load and on each countdown expiry
-         *   - Applies user-configured alert-type filters (AlertFilters) before
-         *     aggregating and rendering so dashboards counts match the offices page
-         *   - Groups impacted offices by severity (Extreme/Severe/Moderate/Minor)
-         *     and renders collapsible severity sections (Moderate and Minor collapsed
-         *     by default to keep the critical information above the fold)
-         *   - Drives a per-second countdown to the next scheduled ingestion cycle
-         *   - Shows a filter indicator in the nav when non-default filters are active
-         *   - Exposes window.exportCurrentData for the export dropdown buttons
-         *
-         * State variables:
-         *   nextUpdateTime    - Date object for the next ingestion cycle; drives countdown
-         *   countdownInterval - setInterval handle; cleared/replaced on each data reload
-         *   observationsMap   - Keyed by office_code; provides temperature for each card
-         *
-         * External dependencies (globals):
-         *   API, AlertFilters, OfficeAggregator, StormScoutExport, debounce, html, raw,
-         *   escapeHtml, truncate, cToF, isStale, timeAgo, formatDate, formatLocalTime,
-         *   getSeverityBadge, renderEmptyHtml, renderErrorHtml, showError — from utils.js
-         */
+/**
+ * page-index.js
+ * Dashboard index page — loads overview stats, impacted offices, top advisories,
+ * and weather observations; drives the update countdown timer.
+ *
+ * Key responsibilities:
+ *   - Fetches overview stats, all active advisories, and weather observations
+ *     in parallel on load and on each countdown expiry
+ *   - Applies user-configured alert-type filters (AlertFilters) before
+ *     aggregating and rendering so dashboards counts match the offices page
+ *   - Groups impacted offices by severity (Extreme/Severe/Moderate/Minor)
+ *     and renders collapsible severity sections (Moderate and Minor collapsed
+ *     by default to keep the critical information above the fold)
+ *   - Drives a per-second countdown to the next scheduled ingestion cycle
+ *   - Shows a filter indicator in the nav when non-default filters are active
+ *   - Exposes window.exportCurrentData for the export dropdown buttons
+ *
+ * State variables:
+ *   nextUpdateTime    - Date object for the next ingestion cycle; drives countdown
+ *   countdownInterval - setInterval handle; cleared/replaced on each data reload
+ *   observationsMap   - Keyed by office_code; provides temperature for each card
+ *
+ * External dependencies (globals):
+ *   API, AlertFilters, OfficeAggregator, StormScoutExport, debounce, html, raw,
+ *   escapeHtml, truncate, cToF, isStale, timeAgo, formatDate, formatLocalTime,
+ *   getSeverityBadge, renderEmptyHtml, renderErrorHtml, showError — from utils.js
+ */
 
-        let nextUpdateTime = null;
-        let countdownInterval = null;
-        let observationsMap = {};
+let nextUpdateTime = null;
+let countdownInterval = null;
+let observationsMap = {};
 
-        /**
-         * Update the "next update" countdown display.
-         * Called once immediately when a new nextUpdateTime is set, then via a
-         * 1-second setInterval. When the countdown expires it triggers a data
-         * reload (with a 2-second delay to allow the backend ingestion cycle to
-         * complete) and stops the current interval.
-         *
-         * @returns {void}
-         */
-        function updateCountdown() {
-            if (!nextUpdateTime) return;
+/**
+ * Update the "next update" countdown display.
+ * Called once immediately when a new nextUpdateTime is set, then via a
+ * 1-second setInterval. When the countdown expires it triggers a data
+ * reload (with a 2-second delay to allow the backend ingestion cycle to
+ * complete) and stops the current interval.
+ *
+ * @returns {void}
+ */
+function updateCountdown() {
+    if (!nextUpdateTime) return;
 
-            const now = new Date();
-            const diff = nextUpdateTime - now;
+    const now = new Date();
+    const diff = nextUpdateTime - now;
 
-            if (diff <= 0) {
-                document.getElementById('nextUpdate').textContent = 'Updating now...';
-                // Reload data after a short delay
-                setTimeout(() => loadOverview(), 2000);
-                return;
-            }
+    if (diff <= 0) {
+        document.getElementById('nextUpdate').textContent = 'Updating now...';
+        // Reload data after a short delay
+        setTimeout(() => loadOverview(), 2000);
+        return;
+    }
 
-            const minutes = Math.floor(diff / 60000);
-            const seconds = Math.floor((diff % 60000) / 1000);
-            document.getElementById('nextUpdate').textContent = `${minutes}m ${seconds}s`;
+    const minutes = Math.floor(diff / 60000);
+    const seconds = Math.floor((diff % 60000) / 1000);
+    document.getElementById('nextUpdate').textContent = `${minutes}m ${seconds}s`;
+}
+
+/**
+ * Fetch all dashboard data in parallel and render the full page.
+ * Uses Promise.all for overview, advisories, and observations so
+ * the three independent requests do not wait on each other.
+ * Applies AlertFilters before aggregating so filtered counts match
+ * the offices and advisories pages.
+ * Wrapped so it can be called both on initial load and by the countdown
+ * when the next ingestion cycle is due.
+ *
+ * @returns {Promise<void>}
+ */
+async function loadOverview() {
+    try {
+        // Get all raw data
+        const [overviewData, allAdvisories, obsData] = await Promise.all([
+            API.getOverview(),
+            API.getActiveAdvisories(),
+            API.getObservations().catch(() => [])
+        ]);
+
+        // Build observations lookup by office_code
+        observationsMap = {};
+        obsData.forEach((obs) => {
+            observationsMap[obs.office_code] = obs;
+        });
+
+        // Update timestamp and countdown
+        document.getElementById('lastUpdated').textContent = formatLocalTime(overviewData.last_updated);
+
+        if (overviewData.last_updated && overviewData.update_interval_minutes) {
+            const lastUpdate = new Date(overviewData.last_updated);
+            nextUpdateTime = new Date(lastUpdate.getTime() + overviewData.update_interval_minutes * 60000);
+
+            // Clear existing countdown interval
+            if (countdownInterval) clearInterval(countdownInterval);
+
+            // Update countdown immediately and then every second
+            updateCountdown();
+            countdownInterval = setInterval(updateCountdown, 1000);
         }
 
-        /**
-         * Fetch all dashboard data in parallel and render the full page.
-         * Uses Promise.all for overview, advisories, and observations so
-         * the three independent requests do not wait on each other.
-         * Applies AlertFilters before aggregating so filtered counts match
-         * the offices and advisories pages.
-         * Wrapped so it can be called both on initial load and by the countdown
-         * when the next ingestion cycle is due.
-         *
-         * @returns {Promise<void>}
-         */
-        async function loadOverview() {
-            try {
-                // Get all raw data
-                const [overviewData, allAdvisories, obsData] = await Promise.all([
-                    API.getOverview(),
-                    API.getActiveAdvisories(),
-                    API.getObservations().catch(() => [])
-                ]);
+        // Apply user's filter preferences
+        const filteredAdvisories = AlertFilters.filterAdvisories(allAdvisories);
 
-                // Build observations lookup by office_code
-                observationsMap = {};
-                obsData.forEach(obs => { observationsMap[obs.office_code] = obs; });
+        // Aggregate by office with deduplication
+        const aggregatedSites = OfficeAggregator.aggregateByOffice(filteredAdvisories, { deduplicateZones: true });
+        const groupedSites = OfficeAggregator.groupBySeverity(aggregatedSites);
 
-                // Update timestamp and countdown
-                document.getElementById('lastUpdated').textContent = formatLocalTime(overviewData.last_updated);
+        // Recalculate counts based on filtered data — set BEFORE rendering cards
+        // so counts always display even if card rendering throws
+        document.getElementById('totalSites').textContent = overviewData.total_offices;
+        document.getElementById('sitesWithAdvisories').textContent = aggregatedSites.length;
 
-                if (overviewData.last_updated && overviewData.update_interval_minutes) {
-                    const lastUpdate = new Date(overviewData.last_updated);
-                    nextUpdateTime = new Date(lastUpdate.getTime() + overviewData.update_interval_minutes * 60000);
+        // Weather Impact Counts - based on sites with filtered advisories only
+        const weatherImpactCounts = { red: 0, orange: 0, yellow: 0, green: 0 };
+        const severityToImpact = { Extreme: 'red', Severe: 'orange', Moderate: 'yellow', Minor: 'green' };
+        aggregatedSites.forEach((site) => {
+            const level = severityToImpact[site.highest_severity] || 'green';
+            weatherImpactCounts[level]++;
+        });
+        document.getElementById('weatherTotal').textContent =
+            weatherImpactCounts.red + weatherImpactCounts.orange + weatherImpactCounts.yellow;
+        document.getElementById('weatherRed').textContent = weatherImpactCounts.red;
+        document.getElementById('weatherOrange').textContent = weatherImpactCounts.orange;
+        document.getElementById('weatherYellow').textContent = weatherImpactCounts.yellow;
 
-                    // Clear existing countdown interval
-                    if (countdownInterval) clearInterval(countdownInterval);
-
-                    // Update countdown immediately and then every second
-                    updateCountdown();
-                    countdownInterval = setInterval(updateCountdown, 1000);
-                }
-
-                // Apply user's filter preferences
-                const filteredAdvisories = AlertFilters.filterAdvisories(allAdvisories);
-
-                // Aggregate by office with deduplication
-                const aggregatedSites = OfficeAggregator.aggregateByOffice(filteredAdvisories, { deduplicateZones: true });
-                const groupedSites = OfficeAggregator.groupBySeverity(aggregatedSites);
-
-                // Recalculate counts based on filtered data — set BEFORE rendering cards
-                // so counts always display even if card rendering throws
-                document.getElementById('totalSites').textContent = overviewData.total_offices;
-                document.getElementById('sitesWithAdvisories').textContent = aggregatedSites.length;
-
-                // Weather Impact Counts - based on sites with filtered advisories only
-                const weatherImpactCounts = { red: 0, orange: 0, yellow: 0, green: 0 };
-                const severityToImpact = { 'Extreme': 'red', 'Severe': 'orange', 'Moderate': 'yellow', 'Minor': 'green' };
-                aggregatedSites.forEach(site => {
-                    const level = severityToImpact[site.highest_severity] || 'green';
-                    weatherImpactCounts[level]++;
-                });
-                document.getElementById('weatherTotal').textContent = weatherImpactCounts.red + weatherImpactCounts.orange + weatherImpactCounts.yellow;
-                document.getElementById('weatherRed').textContent = weatherImpactCounts.red;
-                document.getElementById('weatherOrange').textContent = weatherImpactCounts.orange;
-                document.getElementById('weatherYellow').textContent = weatherImpactCounts.yellow;
-
-                // Render grouped site summaries (wrapped so card errors don't abort the rest)
-                try {
-                    renderSiteGroups(groupedSites);
-                } catch (renderErr) {
-                    console.error('Failed to render site groups:', renderErr);
-                }
-
-                // Show/hide "no sites" message
-                const noSitesMsg = document.getElementById('noSitesMessage');
-                if (aggregatedSites.length === 0) {
-                    noSitesMsg.classList.remove('d-none');
-                } else {
-                    noSitesMsg.classList.add('d-none');
-                }
-
-                // Recalculate severity counts from filtered advisories
-                const severityCounts = {};
-                filteredAdvisories.forEach(adv => {
-                    severityCounts[adv.severity] = (severityCounts[adv.severity] || 0) + 1;
-                });
-
-                const severityOrder = ['Extreme', 'Severe', 'Moderate', 'Minor'];
-                const severityHTML = severityOrder
-                    .filter(sev => severityCounts[sev] > 0)
-                    .map(sev => html`
-                        <div class="mb-2">
-                            <a href="advisories.html?severity=${sev}" class="badge ${raw(getSeverityBadge(sev))} me-2 text-decoration-none">${sev}</a>
-                            <strong>${severityCounts[sev]}</strong> advisories
-                        </div>`
-                    ).join('');
-                document.getElementById('severityCounts').innerHTML = severityHTML || '<p class="text-center text-muted mb-0"><i class="bi bi-cloud-sun me-1"></i>No active advisories</p>';
-
-                // Sites with advisories (filter to show only sites with active advisories)
-                const sitesWithAdvisoriesData = overviewData.recently_updated
-                    .filter(site => {
-                        // Check if this site has any advisories in the filtered set
-                        return filteredAdvisories.some(adv => adv.office_id === site.office_id);
-                    })
-                    .slice(0, 5);
-
-                const sitesHTML = sitesWithAdvisoriesData.map(site => {
-                    const weatherBadge = getWeatherBadge(site.weather_impact_level || 'green');
-                    const opsBadge = getOperationalBadge(site.operational_status || 'open_normal');
-                    return html`<div class="mb-2">
-                        <a href="offices.html?office=${site.office_code}" class="text-decoration-none fw-bold">${site.office_code}</a> - ${site.name}<br>
-                        <small>
-                            <span class="badge ${raw(weatherBadge)} me-1">Weather: ${raw((site.weather_impact_level || 'green').toUpperCase())}</span>
-                            <span class="badge ${raw(opsBadge)}">Ops: ${raw(formatOperationalStatus(site.operational_status || 'open_normal'))}</span>
-                        </small>
-                    </div>`;
-                }).join('');
-                document.getElementById('recentlyUpdatedList').innerHTML = sitesHTML || '<p class="text-center text-muted mb-0"><i class="bi bi-building me-1"></i>No offices with advisories</p>';
-
-                function getWeatherBadge(level) {
-                    const badges = { red: 'weather-red', orange: 'weather-orange', yellow: 'weather-yellow', green: 'weather-green' };
-                    return badges[level] || 'weather-green';
-                }
-
-                function getOperationalBadge(status) {
-                    const badges = { closed: 'status-closed', open_restricted: 'status-restricted', pending: 'status-pending', open_normal: 'status-open' };
-                    return badges[status] || 'status-open';
-                }
-
-                function formatOperationalStatus(status) {
-                    const labels = { closed: 'CLOSED', open_restricted: 'RESTRICTED', pending: 'PENDING', open_normal: 'OPEN' };
-                    return labels[status] || 'OPEN';
-                }
-
-            } catch (error) {
-                console.error('Failed to load overview:', error);
-                showError('Failed to load dashboard data');
-            }
+        // Render grouped site summaries (wrapped so card errors don't abort the rest)
+        try {
+            renderSiteGroups(groupedSites);
+        } catch (renderErr) {
+            console.error('Failed to render site groups:', renderErr);
         }
 
-        /**
-         * Render all four severity group sections.
-         * Colors align with the Weather Impact Assessment colour scheme:
-         *   Extreme → red, Severe → orange, Moderate → yellow, Minor → green.
-         * Moderate and Minor sections default to collapsed to keep the critical
-         * information visible without scrolling on typical dashboards.
-         *
-         * @param {Object} groupedSites - Object with extreme/severe/moderate/minor
-         *                               arrays from OfficeAggregator.groupBySeverity
-         * @returns {void}
-         */
-        function renderSiteGroups(groupedSites) {
-            renderSiteGroup('extremeSitesSection', 'extreme', '<i class="bi bi-circle-fill me-1" aria-hidden="true"></i> EXTREME - High Impact', groupedSites.extreme, false);
-            renderSiteGroup('severeSitesSection', 'severe', '<i class="bi bi-circle-fill me-1" aria-hidden="true"></i> SEVERE - Severe Impact', groupedSites.severe, false);
-            renderSiteGroup('moderateSitesSection', 'moderate', '<i class="bi bi-circle-fill me-1" aria-hidden="true"></i> MODERATE - Moderate Impact', groupedSites.moderate, true);
-            renderSiteGroup('minorSitesSection', 'minor', '<i class="bi bi-circle-fill me-1" aria-hidden="true"></i> MINOR - Low Impact', groupedSites.minor, true);
+        // Show/hide "no sites" message
+        const noSitesMsg = document.getElementById('noSitesMessage');
+        if (aggregatedSites.length === 0) {
+            noSitesMsg.classList.remove('d-none');
+        } else {
+            noSitesMsg.classList.add('d-none');
         }
 
-        /**
-         * Render a single severity group as a collapsible Bootstrap section.
-         * Shows up to 6 office cards inline; a "View All" link to offices.html
-         * is appended when the group has more than 6 members.
-         * Clears the container and returns early when the group is empty to avoid
-         * rendering an empty accordion section.
-         *
-         * @param {string}        containerId - ID of the DOM element to populate
-         * @param {string}        cssClass    - CSS severity class (e.g. 'extreme')
-         * @param {string}        title       - Section heading HTML (may contain icons)
-         * @param {Array<Object>} sites       - Aggregated office objects for this group
-         * @param {boolean}       collapsed   - Whether the section starts collapsed
-         * @returns {void}
-         */
-        function renderSiteGroup(containerId, cssClass, title, sites, collapsed) {
-            const container = document.getElementById(containerId);
+        // Recalculate severity counts from filtered advisories
+        const severityCounts = {};
+        filteredAdvisories.forEach((adv) => {
+            severityCounts[adv.severity] = (severityCounts[adv.severity] || 0) + 1;
+        });
 
-            if (!sites || sites.length === 0) {
-                container.innerHTML = '';
-                return;
-            }
+        const severityOrder = ['Extreme', 'Severe', 'Moderate', 'Minor'];
+        const severityHTML = severityOrder
+            .filter((sev) => severityCounts[sev] > 0)
+            .map(
+                (sev) =>
+                    html` <div class="mb-2">
+                        <a
+                            href="advisories.html?severity=${sev}"
+                            class="badge ${raw(getSeverityBadge(sev))} me-2 text-decoration-none"
+                            >${sev}</a
+                        >
+                        <strong>${severityCounts[sev]}</strong> advisories
+                    </div>`
+            )
+            .join('');
+        document.getElementById('severityCounts').innerHTML =
+            severityHTML ||
+            '<p class="text-center text-muted mb-0"><i class="bi bi-cloud-sun me-1"></i>No active advisories</p>';
 
-            // Sort by office code ascending within severity group
-            const sorted = [...sites].sort((a, b) => a.office_code.localeCompare(b.office_code, undefined, { numeric: true }));
+        // Sites with advisories (filter to show only sites with active advisories)
+        const sitesWithAdvisoriesData = overviewData.recently_updated
+            .filter((site) => {
+                // Check if this site has any advisories in the filtered set
+                return filteredAdvisories.some((adv) => adv.office_id === site.office_id);
+            })
+            .slice(0, 5);
 
-            const collapseId = `collapse${escapeHtml(cssClass)}`;
-            const showClass = collapsed ? '' : 'show';
+        const sitesHTML = sitesWithAdvisoriesData
+            .map((site) => {
+                const weatherBadge = getWeatherBadge(site.weather_impact_level || 'green');
+                const opsBadge = getOperationalBadge(site.operational_status || 'open_normal');
+                return html`<div class="mb-2">
+                    <a href="offices.html?office=${site.office_code}" class="text-decoration-none fw-bold"
+                        >${site.office_code}</a
+                    >
+                    - ${site.name}<br />
+                    <small>
+                        <span class="badge ${raw(weatherBadge)} me-1"
+                            >Weather: ${raw((site.weather_impact_level || 'green').toUpperCase())}</span
+                        >
+                        <span class="badge ${raw(opsBadge)}"
+                            >Ops: ${raw(formatOperationalStatus(site.operational_status || 'open_normal'))}</span
+                        >
+                    </small>
+                </div>`;
+            })
+            .join('');
+        document.getElementById('recentlyUpdatedList').innerHTML =
+            sitesHTML ||
+            '<p class="text-center text-muted mb-0"><i class="bi bi-building me-1"></i>No offices with advisories</p>';
 
-            container.innerHTML = html`
-                <div class="row mb-3">
-                    <div class="col-12">
-                        <div class="severity-group-header ${raw(escapeHtml(cssClass))} ${raw(collapsed ? 'collapsed' : '')}"
-                             data-bs-toggle="collapse"
-                             data-bs-target="#${raw(collapseId)}">
-                            <h4 class="severity-group-title">${raw(title)}</h4>
-                            <span class="severity-group-count">${sites.length}</span>
-                            <span class="severity-group-toggle">▼</span>
-                        </div>
-                        <div class="collapse ${raw(showClass)}" id="${raw(collapseId)}">
-                            <div class="row mt-3">
-                                ${raw(sorted.slice(0, 6).map(site => renderSiteSummary(site, observationsMap[site.office_code])).join(''))}
-                            </div>
-                            ${raw(sorted.length > 6 ? `
+        function getWeatherBadge(level) {
+            const badges = {
+                red: 'weather-red',
+                orange: 'weather-orange',
+                yellow: 'weather-yellow',
+                green: 'weather-green'
+            };
+            return badges[level] || 'weather-green';
+        }
+
+        function getOperationalBadge(status) {
+            const badges = {
+                closed: 'status-closed',
+                open_restricted: 'status-restricted',
+                pending: 'status-pending',
+                open_normal: 'status-open'
+            };
+            return badges[status] || 'status-open';
+        }
+
+        function formatOperationalStatus(status) {
+            const labels = { closed: 'CLOSED', open_restricted: 'RESTRICTED', pending: 'PENDING', open_normal: 'OPEN' };
+            return labels[status] || 'OPEN';
+        }
+    } catch (error) {
+        console.error('Failed to load overview:', error);
+        showError('Failed to load dashboard data');
+    }
+}
+
+/**
+ * Render all four severity group sections.
+ * Colors align with the Weather Impact Assessment colour scheme:
+ *   Extreme → red, Severe → orange, Moderate → yellow, Minor → green.
+ * Moderate and Minor sections default to collapsed to keep the critical
+ * information visible without scrolling on typical dashboards.
+ *
+ * @param {Object} groupedSites - Object with extreme/severe/moderate/minor
+ *                               arrays from OfficeAggregator.groupBySeverity
+ * @returns {void}
+ */
+function renderSiteGroups(groupedSites) {
+    renderSiteGroup(
+        'extremeSitesSection',
+        'extreme',
+        '<i class="bi bi-circle-fill me-1" aria-hidden="true"></i> EXTREME - High Impact',
+        groupedSites.extreme,
+        false
+    );
+    renderSiteGroup(
+        'severeSitesSection',
+        'severe',
+        '<i class="bi bi-circle-fill me-1" aria-hidden="true"></i> SEVERE - Severe Impact',
+        groupedSites.severe,
+        false
+    );
+    renderSiteGroup(
+        'moderateSitesSection',
+        'moderate',
+        '<i class="bi bi-circle-fill me-1" aria-hidden="true"></i> MODERATE - Moderate Impact',
+        groupedSites.moderate,
+        true
+    );
+    renderSiteGroup(
+        'minorSitesSection',
+        'minor',
+        '<i class="bi bi-circle-fill me-1" aria-hidden="true"></i> MINOR - Low Impact',
+        groupedSites.minor,
+        true
+    );
+}
+
+/**
+ * Render a single severity group as a collapsible Bootstrap section.
+ * Shows up to 6 office cards inline; a "View All" link to offices.html
+ * is appended when the group has more than 6 members.
+ * Clears the container and returns early when the group is empty to avoid
+ * rendering an empty accordion section.
+ *
+ * @param {string}        containerId - ID of the DOM element to populate
+ * @param {string}        cssClass    - CSS severity class (e.g. 'extreme')
+ * @param {string}        title       - Section heading HTML (may contain icons)
+ * @param {Array<Object>} sites       - Aggregated office objects for this group
+ * @param {boolean}       collapsed   - Whether the section starts collapsed
+ * @returns {void}
+ */
+function renderSiteGroup(containerId, cssClass, title, sites, collapsed) {
+    const container = document.getElementById(containerId);
+
+    if (!sites || sites.length === 0) {
+        container.innerHTML = '';
+        return;
+    }
+
+    // Sort by office code ascending within severity group
+    const sorted = [...sites].sort((a, b) => a.office_code.localeCompare(b.office_code, undefined, { numeric: true }));
+
+    const collapseId = `collapse${escapeHtml(cssClass)}`;
+    const showClass = collapsed ? '' : 'show';
+
+    container.innerHTML = html`
+        <div class="row mb-3">
+            <div class="col-12">
+                <div
+                    class="severity-group-header ${raw(escapeHtml(cssClass))} ${raw(collapsed ? 'collapsed' : '')}"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#${raw(collapseId)}"
+                >
+                    <h4 class="severity-group-title">${raw(title)}</h4>
+                    <span class="severity-group-count">${sites.length}</span>
+                    <span class="severity-group-toggle">▼</span>
+                </div>
+                <div class="collapse ${raw(showClass)}" id="${raw(collapseId)}">
+                    <div class="row mt-3">
+                        ${raw(
+                            sorted
+                                .slice(0, 6)
+                                .map((site) => renderSiteSummary(site, observationsMap[site.office_code]))
+                                .join('')
+                        )}
+                    </div>
+                    ${raw(
+                        sorted.length > 6
+                            ? `
                             <div class="text-center mt-2">
                                 <a href="offices.html" class="btn btn-sm btn-outline-primary">
                                     View All ${sorted.length} Offices <i class="bi bi-arrow-right"></i>
                                 </a>
                             </div>
-                            ` : '')}
+                            `
+                            : ''
+                    )}
+                </div>
+            </div>
+        </div>
+    `;
+}
+
+/**
+ * Build and return the HTML string for a single office summary card.
+ * Shown inside each severity group section on the dashboard.
+ *
+ * @param {Object}      site - Aggregated office object from OfficeAggregator
+ * @param {Object|null} obs  - Weather observation for this office, or null
+ * @returns {string} HTML string for the card column element
+ */
+function renderSiteSummary(site, obs) {
+    const severityClass = `office-card-${escapeHtml(site.highest_severity.toLowerCase())}`;
+    const advisory = site.highest_severity_advisory || {};
+    const headlineText = truncate(advisory.headline || '', 120);
+
+    const tempHtml = renderTemperatureHTML(obs);
+
+    return html`
+        <div class="col-lg-4 col-md-6 col-12 mb-3">
+            <a href="office-detail.html?office=${site.office_code}" class="text-decoration-none">
+                <div class="card office-card card-clickable ${raw(severityClass)}" style="height: 100%;">
+                    <div class="card-body">
+                        <div class="d-flex justify-content-between align-items-start mb-2">
+                            <h6 class="mb-0 text-dark">
+                                <strong>${site.office_code}</strong> - ${site.office_name}<br />
+                                <small class="text-muted">${site.city}, ${site.state}</small>
+                            </h6>
+                            <div style="text-align: right;">
+                                <span
+                                    class="badge severity-badge severity-${raw(
+                                        escapeHtml(site.highest_severity.toLowerCase())
+                                    )}"
+                                >
+                                    ${site.highest_severity}
+                                </span>
+                                ${raw(tempHtml)}
+                            </div>
+                        </div>
+
+                        <div class="mb-2 text-dark">
+                            <strong>${advisory.advisory_type}</strong>
+                            ${raw(
+                                advisory.vtec_action === 'NEW'
+                                    ? '<span class="badge action-badge-new ms-1"><i class="bi bi-bell-fill"></i> NEW</span>'
+                                    : ''
+                            )}
+                            ${raw(
+                                headlineText
+                                    ? '<br><small class="text-muted" style="line-height: 1.3; display: inline-block; margin-top: 0.25rem;">' +
+                                          escapeHtml(headlineText) +
+                                          '</small>'
+                                    : ''
+                            )}
+                        </div>
+
+                        <small class="text-muted d-block mb-2">
+                            ${raw(advisory.expires ? 'Expires: ' + formatDate(advisory.expires) : '')}
+                        </small>
+
+                        <div class="d-flex gap-2 align-items-center text-dark" style="font-size: 0.85rem;">
+                            <span>
+                                <strong>${site.unique_advisory_count}</strong> ${raw(
+                                    site.unique_advisory_count === 1 ? 'alert' : 'alerts'
+                                )}
+                            </span>
+                            ${raw(
+                                site.total_zone_count !== site.unique_advisory_count
+                                    ? `<span class="text-muted">(${site.total_zone_count} zones)</span>`
+                                    : ''
+                            )}
+                            ${raw(
+                                site.new_count > 0 ? `<span class="badge bg-success">${site.new_count} new</span>` : ''
+                            )}
                         </div>
                     </div>
                 </div>
-            `;
+            </a>
+        </div>
+    `;
+}
+
+/**
+ * Show or update the filter indicator badge in the nav bar.
+ * Displayed only when AlertFilters.hasActiveFilters() returns true so that
+ * operators are reminded that some alert types are suppressed.
+ *
+ * @returns {void}
+ */
+function updateFilterIndicator() {
+    const indicator = document.getElementById('filterIndicator');
+    const filterCount = document.getElementById('filterCount');
+    const filterTotal = document.getElementById('filterTotal');
+
+    if (!indicator || !AlertFilters.alertTypesByLevel) return;
+
+    const enabled = AlertFilters.getEnabledCount();
+    const total = AlertFilters.getTotalAlertTypes();
+
+    filterCount.textContent = enabled;
+    filterTotal.textContent = total;
+
+    // Show indicator only if filters are active (not showing all)
+    if (AlertFilters.hasActiveFilters()) {
+        indicator.classList.remove('d-none');
+    } else {
+        indicator.classList.add('d-none');
+    }
+}
+
+// Initialize filters then load overview
+AlertFilters.init().then(() => {
+    updateFilterIndicator();
+    loadOverview();
+});
+
+// Helper function to export current dashboard data
+window.exportCurrentData = async function (type) {
+    try {
+        // Fetch current data
+        const overviewResponse = await fetch('/api/status/overview');
+        const officesResponse = await fetch('/api/status/offices-impacted');
+        const advisoriesResponse = await fetch('/api/advisories/active');
+
+        if (!overviewResponse.ok || !officesResponse.ok || !advisoriesResponse.ok) {
+            throw new Error('Failed to fetch data for export');
         }
 
-        /**
-         * Build and return the HTML string for a single office summary card.
-         * Shown inside each severity group section on the dashboard.
-         *
-         * @param {Object}      site - Aggregated office object from OfficeAggregator
-         * @param {Object|null} obs  - Weather observation for this office, or null
-         * @returns {string} HTML string for the card column element
-         */
-        function renderSiteSummary(site, obs) {
-            const severityClass = `office-card-${escapeHtml(site.highest_severity.toLowerCase())}`;
-            const advisory = site.highest_severity_advisory || {};
-            const headlineText = truncate(advisory.headline || '', 120);
+        const overview = await overviewResponse.json();
+        const officesData = await officesResponse.json();
+        const advisories = await advisoriesResponse.json();
 
-            const tempHtml = renderTemperatureHTML(obs);
+        // Extract offices array from the response
+        const offices = Array.isArray(officesData.data) ? officesData.data : [];
 
-            return html`
-                <div class="col-lg-4 col-md-6 col-12 mb-3">
-                    <a href="office-detail.html?office=${site.office_code}" class="text-decoration-none">
-                        <div class="card office-card card-clickable ${raw(severityClass)}" style="height: 100%;">
-                            <div class="card-body">
-                                <div class="d-flex justify-content-between align-items-start mb-2">
-                                    <h6 class="mb-0 text-dark">
-                                        <strong>${site.office_code}</strong> - ${site.office_name}<br>
-                                        <small class="text-muted">${site.city}, ${site.state}</small>
-                                    </h6>
-                                    <div style="text-align: right;">
-                                        <span class="badge severity-badge severity-${raw(escapeHtml(site.highest_severity.toLowerCase()))}">
-                                            ${site.highest_severity}
-                                        </span>
-                                        ${raw(tempHtml)}
-                                    </div>
-                                </div>
-
-                                <div class="mb-2 text-dark">
-                                    <strong>${advisory.advisory_type}</strong>
-                                    ${raw(advisory.vtec_action === 'NEW' ? '<span class="badge action-badge-new ms-1"><i class="bi bi-bell-fill"></i> NEW</span>' : '')}
-                                    ${raw(headlineText ? '<br><small class="text-muted" style="line-height: 1.3; display: inline-block; margin-top: 0.25rem;">' + escapeHtml(headlineText) + '</small>' : '')}
-                                </div>
-
-                                <small class="text-muted d-block mb-2">
-                                    ${raw(advisory.expires ? 'Expires: ' + formatDate(advisory.expires) : '')}
-                                </small>
-
-                                <div class="d-flex gap-2 align-items-center text-dark" style="font-size: 0.85rem;">
-                                    <span>
-                                        <strong>${site.unique_advisory_count}</strong> ${raw(site.unique_advisory_count === 1 ? 'alert' : 'alerts')}
-                                    </span>
-                                    ${raw(site.total_zone_count !== site.unique_advisory_count ?
-                                        `<span class="text-muted">(${site.total_zone_count} zones)</span>` : '')}
-                                    ${raw(site.new_count > 0 ?
-                                        `<span class="badge bg-success">${site.new_count} new</span>` : '')}
-                                </div>
-                            </div>
-                        </div>
-                    </a>
-                </div>
-            `;
+        // Export based on type
+        switch (type) {
+            case 'csv':
+                StormScoutExport.exportOfficesToCSV(offices);
+                break;
+            case 'executive':
+                StormScoutExport.generateHTMLReport({ offices, advisories, overview }, 'executive');
+                break;
+            case 'incident':
+                StormScoutExport.generateHTMLReport({ offices, advisories }, 'incident');
+                break;
+            case 'summary':
+                StormScoutExport.generateHTMLReport({ offices }, 'summary');
+                break;
+            default:
+                console.error('Unknown export type:', type);
         }
+    } catch (error) {
+        console.error('Export failed:', error);
+        StormScoutExport.showNotification('✗ Export failed', 'error');
+    }
+};
 
-        /**
-         * Show or update the filter indicator badge in the nav bar.
-         * Displayed only when AlertFilters.hasActiveFilters() returns true so that
-         * operators are reminded that some alert types are suppressed.
-         *
-         * @returns {void}
-         */
-        function updateFilterIndicator() {
-            const indicator = document.getElementById('filterIndicator');
-            const filterCount = document.getElementById('filterCount');
-            const filterTotal = document.getElementById('filterTotal');
-
-            if (!indicator || !AlertFilters.alertTypesByLevel) return;
-
-            const enabled = AlertFilters.getEnabledCount();
-            const total = AlertFilters.getTotalAlertTypes();
-
-            filterCount.textContent = enabled;
-            filterTotal.textContent = total;
-
-            // Show indicator only if filters are active (not showing all)
-            if (AlertFilters.hasActiveFilters()) {
-                indicator.classList.remove('d-none');
-            } else {
-                indicator.classList.add('d-none');
-            }
-        }
-
-        // Initialize filters then load overview
-        AlertFilters.init().then(() => {
-            updateFilterIndicator();
-            loadOverview();
-        });
-
-        // Helper function to export current dashboard data
-        window.exportCurrentData = async function(type) {
-            try {
-                // Fetch current data
-                const overviewResponse = await fetch('/api/status/overview');
-                const officesResponse = await fetch('/api/status/offices-impacted');
-                const advisoriesResponse = await fetch('/api/advisories/active');
-
-                if (!overviewResponse.ok || !officesResponse.ok || !advisoriesResponse.ok) {
-                    throw new Error('Failed to fetch data for export');
-                }
-
-                const overview = await overviewResponse.json();
-                const officesData = await officesResponse.json();
-                const advisories = await advisoriesResponse.json();
-
-                // Extract offices array from the response
-                const offices = Array.isArray(officesData.data) ? officesData.data : [];
-
-                // Export based on type
-                switch(type) {
-                    case 'csv':
-                        StormScoutExport.exportOfficesToCSV(offices);
-                        break;
-                    case 'executive':
-                        StormScoutExport.generateHTMLReport({ offices, advisories, overview }, 'executive');
-                        break;
-                    case 'incident':
-                        StormScoutExport.generateHTMLReport({ offices, advisories }, 'incident');
-                        break;
-                    case 'summary':
-                        StormScoutExport.generateHTMLReport({ offices }, 'summary');
-                        break;
-                    default:
-                        console.error('Unknown export type:', type);
-                }
-            } catch (error) {
-                console.error('Export failed:', error);
-                StormScoutExport.showNotification('✗ Export failed', 'error');
-            }
-        };
-
-        // Event listeners for export buttons (CSP-compliant)
-        document.getElementById('exportPrintPDF').addEventListener('click', (e) => { e.preventDefault(); StormScoutExport.printToPDF(); });
-        document.getElementById('exportShareLink').addEventListener('click', (e) => { e.preventDefault(); StormScoutExport.copyShareableLink(); });
-        document.getElementById('exportExecutive').addEventListener('click', (e) => { e.preventDefault(); exportCurrentData('executive'); });
-        document.getElementById('exportIncident').addEventListener('click', (e) => { e.preventDefault(); exportCurrentData('incident'); });
-        document.getElementById('exportCSV').addEventListener('click', (e) => { e.preventDefault(); exportCurrentData('csv'); });
+// Event listeners for export buttons (CSP-compliant)
+document.getElementById('exportPrintPDF').addEventListener('click', (e) => {
+    e.preventDefault();
+    StormScoutExport.printToPDF();
+});
+document.getElementById('exportShareLink').addEventListener('click', (e) => {
+    e.preventDefault();
+    StormScoutExport.copyShareableLink();
+});
+document.getElementById('exportExecutive').addEventListener('click', (e) => {
+    e.preventDefault();
+    exportCurrentData('executive');
+});
+document.getElementById('exportIncident').addEventListener('click', (e) => {
+    e.preventDefault();
+    exportCurrentData('incident');
+});
+document.getElementById('exportCSV').addEventListener('click', (e) => {
+    e.preventDefault();
+    exportCurrentData('csv');
+});

--- a/frontend/js/page-map.js
+++ b/frontend/js/page-map.js
@@ -1,269 +1,290 @@
-        let map;
-        let markers = [];
-        let markerLayer;
-        let observationsMap = {};
+let map;
+let markers = [];
+let markerLayer;
+let observationsMap = {};
 
-        // Severity rank — lower index = higher priority (closes #108)
-        const SEVERITY_ORDER = ['Extreme', 'Severe', 'Moderate', 'Minor', 'Unknown'];
+// Severity rank — lower index = higher priority (closes #108)
+const SEVERITY_ORDER = ['Extreme', 'Severe', 'Moderate', 'Minor', 'Unknown'];
 
-        /**
-         * Create a severity-aware cluster icon.
-         * Colors the cluster badge by the highest-severity child marker.
-         */
-        function createClusterIcon(cluster) {
-            const children = cluster.getAllChildMarkers();
-            let topSeverity = 'Unknown';
-            for (const child of children) {
-                const s = child.options.severity || 'Unknown';
-                if (SEVERITY_ORDER.indexOf(s) < SEVERITY_ORDER.indexOf(topSeverity)) {
-                    topSeverity = s;
-                }
+/**
+ * Create a severity-aware cluster icon.
+ * Colors the cluster badge by the highest-severity child marker.
+ */
+function createClusterIcon(cluster) {
+    const children = cluster.getAllChildMarkers();
+    let topSeverity = 'Unknown';
+    for (const child of children) {
+        const s = child.options.severity || 'Unknown';
+        if (SEVERITY_ORDER.indexOf(s) < SEVERITY_ORDER.indexOf(topSeverity)) {
+            topSeverity = s;
+        }
+    }
+    const severityClass = `marker-${topSeverity.toLowerCase()}`;
+    return L.divIcon({
+        html: `<div class="severity-marker ${escapeHtml(severityClass)}" style="width:36px;height:36px;font-size:14px;">${cluster.getChildCount()}</div>`,
+        className: '',
+        iconSize: [36, 36],
+        iconAnchor: [18, 18]
+    });
+}
+
+// Initialize map
+function initMap() {
+    map = L.map('map').setView([39.8283, -98.5795], 4); // Center of USA
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+        maxZoom: 19
+    }).addTo(map);
+
+    markerLayer = L.markerClusterGroup({
+        maxClusterRadius: 60,
+        iconCreateFunction: createClusterIcon
+    }).addTo(map);
+}
+
+function debugStep(text) {
+    const list = document.getElementById('mapDebugSteps');
+    if (list) {
+        const li = document.createElement('li');
+        li.textContent = text;
+        list.appendChild(li);
+    }
+}
+
+async function loadMapData() {
+    try {
+        debugStep('Starting: AlertFilters.init()');
+        const filtersLoaded = await AlertFilters.init();
+        debugStep('AlertFilters.init() returned: ' + filtersLoaded);
+        if (!filtersLoaded) throw new Error('Alert filter initialization failed');
+
+        debugStep('Fetching advisories, offices, observations...');
+        const [allAdvisories, allOffices, obsData] = await Promise.all([
+            API.getActiveAdvisories(),
+            API.getOffices(),
+            API.getObservations().catch(() => [])
+        ]);
+        debugStep(
+            'APIs returned — advisories:' +
+                allAdvisories.length +
+                ' offices:' +
+                allOffices.length +
+                ' obs:' +
+                obsData.length
+        );
+
+        observationsMap = {};
+        obsData.forEach((obs) => {
+            observationsMap[obs.office_code] = obs;
+        });
+
+        debugStep('Filtering advisories...');
+        const filteredAdvisories = AlertFilters.filterAdvisories(allAdvisories);
+        debugStep('filteredAdvisories: ' + filteredAdvisories.length);
+
+        debugStep('Aggregating by office...');
+        const aggregated = OfficeAggregator.aggregateByOffice(filteredAdvisories, { deduplicateZones: true });
+        debugStep('aggregated offices: ' + aggregated.length);
+
+        const aggMap = new Map();
+        aggregated.forEach((office) => {
+            aggMap.set(office.office_id, office);
+        });
+
+        const officesWithAdvisories = allOffices
+            .filter((office) => aggMap.has(office.id))
+            .map((office) => ({ ...office, ...aggMap.get(office.id) }));
+        debugStep('officesWithAdvisories: ' + officesWithAdvisories.length);
+
+        debugStep('Calling renderMarkers...');
+        renderMarkers(officesWithAdvisories);
+        debugStep('Calling updateStats...');
+        updateStats(aggregated);
+        debugStep('Done.');
+    } catch (error) {
+        console.error('Failed to load map data:', error);
+        const banner = document.getElementById('mapErrorBanner');
+        const msg = document.getElementById('mapErrorMessage');
+        if (msg) msg.textContent = 'Error: ' + error.message + ' (' + error.constructor.name + ')';
+        if (banner) banner.classList.remove('d-none');
+    }
+}
+
+function renderMarkers(offices) {
+    // Clear existing markers
+    markerLayer.clearLayers();
+    markers = [];
+
+    offices.forEach((office) => {
+        if (!office.latitude || !office.longitude) return;
+
+        const severity = office.highest_severity || 'Minor';
+        const severityClass = `marker-${severity.toLowerCase()}`;
+
+        // Create custom div icon with escaped values
+        const iconHtml = `<div class="severity-marker ${escapeHtml(severityClass)}" style="width: 30px; height: 30px;">${parseInt(office.unique_advisory_count) || 0}</div>`;
+        const customIcon = L.divIcon({
+            html: iconHtml,
+            className: '',
+            iconSize: [30, 30],
+            iconAnchor: [15, 15],
+            popupAnchor: [0, -15]
+        });
+
+        // Create marker — store severity as custom option for cluster icon access
+        const marker = L.marker([office.latitude, office.longitude], { icon: customIcon, severity });
+
+        // Create popup content using html tagged template for XSS prevention
+        const obs = observationsMap[office.office_code];
+        const tempHtml = renderTemperatureHTML(obs);
+
+        const headlineText = truncate(office.highest_severity_advisory.headline || '', 80);
+
+        const popupContent = html`
+            <div class="office-popup">
+                <h6><strong>${office.office_code}</strong> - ${office.name}</h6>
+                <div class="d-flex justify-content-between align-items-center mb-2">
+                    <span>${raw('<i class="bi bi-geo-alt"></i>')} ${office.city}, ${office.state}</span>
+                    ${raw(tempHtml ? `<span class="temp-display d-inline-block">${tempHtml}</span>` : '')}
+                </div>
+                <p class="mb-2">
+                    ${raw(
+                        `<span class="badge severity-${escapeHtml(severity.toLowerCase())}">${escapeHtml(severity)}</span>`
+                    )}
+                    ${raw(office.new_count > 0 ? `<span class="badge bg-success">${office.new_count} NEW</span>` : '')}
+                </p>
+                <p class="mb-1"><strong>${office.highest_severity_advisory.advisory_type}</strong></p>
+                ${raw(
+                    headlineText
+                        ? `<p class="mb-2"><small class="text-muted">${escapeHtml(headlineText)}</small></p>`
+                        : ''
+                )}
+                <p class="mb-2">
+                    <strong>${office.unique_advisory_count}</strong> unique alerts
+                    ${raw(
+                        office.total_zone_count !== office.unique_advisory_count
+                            ? `<small class="text-muted">(${office.total_zone_count} zones)</small>`
+                            : ''
+                    )}
+                </p>
+                <a
+                    href="office-detail.html?office=${encodeURIComponent(office.office_code)}"
+                    class="btn btn-sm btn-primary w-100"
+                >
+                    ${raw('<i class="bi bi-arrow-right-circle"></i>')} View Details
+                </a>
+            </div>
+        `;
+
+        marker.bindPopup(popupContent);
+
+        // Add to layer and tracking
+        marker.addTo(markerLayer);
+        markers.push({
+            marker,
+            office,
+            severity
+        });
+    });
+
+    // Fit map to show all markers
+    if (markers.length > 0) {
+        const group = L.featureGroup(markers.map((m) => m.marker));
+        map.fitBounds(group.getBounds().pad(0.1));
+    }
+
+    updateVisibleCount();
+}
+
+function updateStats(offices) {
+    const counts = {
+        extreme: offices.filter((o) => o.highest_severity === 'Extreme').length,
+        severe: offices.filter((o) => o.highest_severity === 'Severe').length,
+        moderate: offices.filter((o) => o.highest_severity === 'Moderate').length
+    };
+
+    document.getElementById('extremeCount').textContent = counts.extreme;
+    document.getElementById('severeCount').textContent = counts.severe;
+    document.getElementById('moderateCount').textContent = counts.moderate;
+    document.getElementById('totalOfficesCount').textContent = offices.length;
+}
+
+function updateVisibleCount() {
+    const visible = markers.filter((m) => map.getBounds().contains(m.marker.getLatLng())).length;
+    document.getElementById('visibleOfficeCount').textContent = `${visible} offices visible`;
+}
+
+function fitAllMarkers() {
+    if (markers.length > 0) {
+        const group = L.featureGroup(markers.map((m) => m.marker));
+        map.fitBounds(group.getBounds().pad(0.1));
+    }
+}
+
+function resetMap() {
+    map.setView([39.8283, -98.5795], 4);
+    document.getElementById('filterExtreme').checked = true;
+    document.getElementById('filterSevere').checked = true;
+    document.getElementById('filterModerate').checked = true;
+    applyFilters();
+}
+
+function applyFilters() {
+    const showExtreme = document.getElementById('filterExtreme').checked;
+    const showSevere = document.getElementById('filterSevere').checked;
+    const showModerate = document.getElementById('filterModerate').checked;
+
+    markers.forEach(({ marker, severity }) => {
+        const show =
+            (severity === 'Extreme' && showExtreme) ||
+            (severity === 'Severe' && showSevere) ||
+            (severity === 'Moderate' && showModerate) ||
+            severity === 'Minor';
+
+        if (show) {
+            marker.addTo(markerLayer);
+        } else {
+            markerLayer.removeLayer(marker);
+        }
+    });
+
+    updateVisibleCount();
+    updateStatCardStyles();
+}
+
+function toggleFilter(severity) {
+    const checkbox = document.getElementById(`filter${severity}`);
+    checkbox.checked = !checkbox.checked;
+    applyFilters();
+}
+
+function updateStatCardStyles() {
+    const filters = ['Extreme', 'Severe', 'Moderate'];
+    filters.forEach((severity) => {
+        const checkbox = document.getElementById(`filter${severity}`);
+        const card = document.querySelector(`.map-stat-card[data-severity="${severity}"]`);
+        if (card) {
+            if (checkbox.checked) {
+                card.classList.remove('filter-disabled');
+            } else {
+                card.classList.add('filter-disabled');
             }
-            const severityClass = `marker-${topSeverity.toLowerCase()}`;
-            return L.divIcon({
-                html: `<div class="severity-marker ${escapeHtml(severityClass)}" style="width:36px;height:36px;font-size:14px;">${cluster.getChildCount()}</div>`,
-                className: '',
-                iconSize: [36, 36],
-                iconAnchor: [18, 18]
-            });
         }
+    });
+}
 
-        // Initialize map
-        function initMap() {
-            map = L.map('map').setView([39.8283, -98.5795], 4); // Center of USA
+// Event listeners
+document.getElementById('filterExtreme').addEventListener('change', applyFilters);
+document.getElementById('filterSevere').addEventListener('change', applyFilters);
+document.getElementById('filterModerate').addEventListener('change', applyFilters);
+document.getElementById('fitAllBtn').addEventListener('click', fitAllMarkers);
+document.getElementById('resetMapBtn').addEventListener('click', resetMap);
+document.getElementById('toggleExtreme').addEventListener('click', () => toggleFilter('Extreme'));
+document.getElementById('toggleSevere').addEventListener('click', () => toggleFilter('Severe'));
+document.getElementById('toggleModerate').addEventListener('click', () => toggleFilter('Moderate'));
 
-            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-                maxZoom: 19
-            }).addTo(map);
-
-            markerLayer = L.markerClusterGroup({
-                maxClusterRadius: 60,
-                iconCreateFunction: createClusterIcon
-            }).addTo(map);
-        }
-
-        function debugStep(text) {
-            const list = document.getElementById('mapDebugSteps');
-            if (list) {
-                const li = document.createElement('li');
-                li.textContent = text;
-                list.appendChild(li);
-            }
-        }
-
-        async function loadMapData() {
-            try {
-                debugStep('Starting: AlertFilters.init()');
-                const filtersLoaded = await AlertFilters.init();
-                debugStep('AlertFilters.init() returned: ' + filtersLoaded);
-                if (!filtersLoaded) throw new Error('Alert filter initialization failed');
-
-                debugStep('Fetching advisories, offices, observations...');
-                const [allAdvisories, allOffices, obsData] = await Promise.all([
-                    API.getActiveAdvisories(),
-                    API.getOffices(),
-                    API.getObservations().catch(() => [])
-                ]);
-                debugStep('APIs returned — advisories:' + allAdvisories.length + ' offices:' + allOffices.length + ' obs:' + obsData.length);
-
-                observationsMap = {};
-                obsData.forEach(obs => { observationsMap[obs.office_code] = obs; });
-
-                debugStep('Filtering advisories...');
-                const filteredAdvisories = AlertFilters.filterAdvisories(allAdvisories);
-                debugStep('filteredAdvisories: ' + filteredAdvisories.length);
-
-                debugStep('Aggregating by office...');
-                const aggregated = OfficeAggregator.aggregateByOffice(filteredAdvisories, { deduplicateZones: true });
-                debugStep('aggregated offices: ' + aggregated.length);
-
-                const aggMap = new Map();
-                aggregated.forEach(office => { aggMap.set(office.office_id, office); });
-
-                const officesWithAdvisories = allOffices
-                    .filter(office => aggMap.has(office.id))
-                    .map(office => ({ ...office, ...aggMap.get(office.id) }));
-                debugStep('officesWithAdvisories: ' + officesWithAdvisories.length);
-
-                debugStep('Calling renderMarkers...');
-                renderMarkers(officesWithAdvisories);
-                debugStep('Calling updateStats...');
-                updateStats(aggregated);
-                debugStep('Done.');
-
-            } catch (error) {
-                console.error('Failed to load map data:', error);
-                const banner = document.getElementById('mapErrorBanner');
-                const msg = document.getElementById('mapErrorMessage');
-                if (msg) msg.textContent = 'Error: ' + error.message + ' (' + error.constructor.name + ')';
-                if (banner) banner.classList.remove('d-none');
-            }
-        }
-
-        function renderMarkers(offices) {
-            // Clear existing markers
-            markerLayer.clearLayers();
-            markers = [];
-
-            offices.forEach(office => {
-                if (!office.latitude || !office.longitude) return;
-
-                const severity = office.highest_severity || 'Minor';
-                const severityClass = `marker-${severity.toLowerCase()}`;
-
-                // Create custom div icon with escaped values
-                const iconHtml = `<div class="severity-marker ${escapeHtml(severityClass)}" style="width: 30px; height: 30px;">${parseInt(office.unique_advisory_count) || 0}</div>`;
-                const customIcon = L.divIcon({
-                    html: iconHtml,
-                    className: '',
-                    iconSize: [30, 30],
-                    iconAnchor: [15, 15],
-                    popupAnchor: [0, -15]
-                });
-
-                // Create marker — store severity as custom option for cluster icon access
-                const marker = L.marker([office.latitude, office.longitude], { icon: customIcon, severity });
-
-                // Create popup content using html tagged template for XSS prevention
-                const obs = observationsMap[office.office_code];
-                const tempHtml = renderTemperatureHTML(obs);
-
-                const headlineText = truncate(office.highest_severity_advisory.headline || '', 80);
-
-                const popupContent = html`
-                    <div class="office-popup">
-                        <h6><strong>${office.office_code}</strong> - ${office.name}</h6>
-                        <div class="d-flex justify-content-between align-items-center mb-2">
-                            <span>${raw('<i class="bi bi-geo-alt"></i>')} ${office.city}, ${office.state}</span>
-                            ${raw(tempHtml ? `<span class="temp-display d-inline-block">${tempHtml}</span>` : '')}
-                        </div>
-                        <p class="mb-2">
-                            ${raw(`<span class="badge severity-${escapeHtml(severity.toLowerCase())}">${escapeHtml(severity)}</span>`)}
-                            ${raw(office.new_count > 0 ? `<span class="badge bg-success">${office.new_count} NEW</span>` : '')}
-                        </p>
-                        <p class="mb-1"><strong>${office.highest_severity_advisory.advisory_type}</strong></p>
-                        ${raw(headlineText ? `<p class="mb-2"><small class="text-muted">${escapeHtml(headlineText)}</small></p>` : '')}
-                        <p class="mb-2">
-                            <strong>${office.unique_advisory_count}</strong> unique alerts
-                            ${raw(office.total_zone_count !== office.unique_advisory_count ?
-                                `<small class="text-muted">(${office.total_zone_count} zones)</small>` : '')}
-                        </p>
-                        <a href="office-detail.html?office=${encodeURIComponent(office.office_code)}" class="btn btn-sm btn-primary w-100">
-                            ${raw('<i class="bi bi-arrow-right-circle"></i>')} View Details
-                        </a>
-                    </div>
-                `;
-
-                marker.bindPopup(popupContent);
-
-                // Add to layer and tracking
-                marker.addTo(markerLayer);
-                markers.push({
-                    marker,
-                    office,
-                    severity
-                });
-            });
-
-            // Fit map to show all markers
-            if (markers.length > 0) {
-                const group = L.featureGroup(markers.map(m => m.marker));
-                map.fitBounds(group.getBounds().pad(0.1));
-            }
-
-            updateVisibleCount();
-        }
-
-        function updateStats(offices) {
-            const counts = {
-                extreme: offices.filter(o => o.highest_severity === 'Extreme').length,
-                severe: offices.filter(o => o.highest_severity === 'Severe').length,
-                moderate: offices.filter(o => o.highest_severity === 'Moderate').length
-            };
-
-            document.getElementById('extremeCount').textContent = counts.extreme;
-            document.getElementById('severeCount').textContent = counts.severe;
-            document.getElementById('moderateCount').textContent = counts.moderate;
-            document.getElementById('totalOfficesCount').textContent = offices.length;
-        }
-
-        function updateVisibleCount() {
-            const visible = markers.filter(m => map.getBounds().contains(m.marker.getLatLng())).length;
-            document.getElementById('visibleOfficeCount').textContent = `${visible} offices visible`;
-        }
-
-        function fitAllMarkers() {
-            if (markers.length > 0) {
-                const group = L.featureGroup(markers.map(m => m.marker));
-                map.fitBounds(group.getBounds().pad(0.1));
-            }
-        }
-
-        function resetMap() {
-            map.setView([39.8283, -98.5795], 4);
-            document.getElementById('filterExtreme').checked = true;
-            document.getElementById('filterSevere').checked = true;
-            document.getElementById('filterModerate').checked = true;
-            applyFilters();
-        }
-
-        function applyFilters() {
-            const showExtreme = document.getElementById('filterExtreme').checked;
-            const showSevere = document.getElementById('filterSevere').checked;
-            const showModerate = document.getElementById('filterModerate').checked;
-
-            markers.forEach(({ marker, severity }) => {
-                const show = (
-                    (severity === 'Extreme' && showExtreme) ||
-                    (severity === 'Severe' && showSevere) ||
-                    (severity === 'Moderate' && showModerate) ||
-                    severity === 'Minor'
-                );
-
-                if (show) {
-                    marker.addTo(markerLayer);
-                } else {
-                    markerLayer.removeLayer(marker);
-                }
-            });
-
-            updateVisibleCount();
-            updateStatCardStyles();
-        }
-
-        function toggleFilter(severity) {
-            const checkbox = document.getElementById(`filter${severity}`);
-            checkbox.checked = !checkbox.checked;
-            applyFilters();
-        }
-
-        function updateStatCardStyles() {
-            const filters = ['Extreme', 'Severe', 'Moderate'];
-            filters.forEach(severity => {
-                const checkbox = document.getElementById(`filter${severity}`);
-                const card = document.querySelector(`.map-stat-card[data-severity="${severity}"]`);
-                if (card) {
-                    if (checkbox.checked) {
-                        card.classList.remove('filter-disabled');
-                    } else {
-                        card.classList.add('filter-disabled');
-                    }
-                }
-            });
-        }
-
-        // Event listeners
-        document.getElementById('filterExtreme').addEventListener('change', applyFilters);
-        document.getElementById('filterSevere').addEventListener('change', applyFilters);
-        document.getElementById('filterModerate').addEventListener('change', applyFilters);
-        document.getElementById('fitAllBtn').addEventListener('click', fitAllMarkers);
-        document.getElementById('resetMapBtn').addEventListener('click', resetMap);
-        document.getElementById('toggleExtreme').addEventListener('click', () => toggleFilter('Extreme'));
-        document.getElementById('toggleSevere').addEventListener('click', () => toggleFilter('Severe'));
-        document.getElementById('toggleModerate').addEventListener('click', () => toggleFilter('Moderate'));
-
-        // Initialize
-        initMap();
-        map.on('moveend', updateVisibleCount);
-        loadMapData();
+// Initialize
+initMap();
+map.on('moveend', updateVisibleCount);
+loadMapData();

--- a/frontend/js/page-notices.js
+++ b/frontend/js/page-notices.js
@@ -1,56 +1,61 @@
-        /**
-         * page-notices.js
-         * Notices page — displays active government and operational notices.
-         *
-         * Key responsibilities:
-         *   - Fetches all currently active notices from the API
-         *   - Renders each notice as a card with jurisdiction, type, description,
-         *     effective date, affected states, and an optional source link
-         *   - Supports filtering by jurisdiction type (Federal, State, Local)
-         *
-         * State variables:
-         *   allNotices - Full list of active notices; filtered client-side on change
-         *
-         * External dependencies (globals):
-         *   API, html, raw, escapeHtml, formatDate, renderEmptyHtml, renderErrorHtml
-         */
+/**
+ * page-notices.js
+ * Notices page — displays active government and operational notices.
+ *
+ * Key responsibilities:
+ *   - Fetches all currently active notices from the API
+ *   - Renders each notice as a card with jurisdiction, type, description,
+ *     effective date, affected states, and an optional source link
+ *   - Supports filtering by jurisdiction type (Federal, State, Local)
+ *
+ * State variables:
+ *   allNotices - Full list of active notices; filtered client-side on change
+ *
+ * External dependencies (globals):
+ *   API, html, raw, escapeHtml, formatDate, renderEmptyHtml, renderErrorHtml
+ */
 
-        let allNotices = [];
+let allNotices = [];
 
-        /**
-         * Fetch all active notices from the API and perform the initial render.
-         * On error, an inline error message is displayed in the container element.
-         *
-         * @returns {Promise<void>}
-         */
-        async function loadNotices() {
-            try {
-                const data = await API.getActiveNotices();
-                allNotices = data;
-                renderNotices(data);
-            } catch (error) {
-                document.getElementById('noticesContainer').innerHTML =
-                    renderErrorHtml('Failed to load notices');
-            }
-        }
+/**
+ * Fetch all active notices from the API and perform the initial render.
+ * On error, an inline error message is displayed in the container element.
+ *
+ * @returns {Promise<void>}
+ */
+async function loadNotices() {
+    try {
+        const data = await API.getActiveNotices();
+        allNotices = data;
+        renderNotices(data);
+    } catch (error) {
+        document.getElementById('noticesContainer').innerHTML = renderErrorHtml('Failed to load notices');
+    }
+}
 
-        /**
-         * Render the provided notices list into the notices container.
-         * Shows an empty-state placeholder when the list is empty.
-         *
-         * @param {Array<Object>} notices - Notice records to render; each record
-         *   has at minimum: title, jurisdiction_type, jurisdiction, notice_type,
-         *   description, effective_time, affected_states, and optionally source_url
-         * @returns {void}
-         */
-        function renderNotices(notices) {
-            const container = document.getElementById('noticesContainer');
-            if (notices.length === 0) {
-                container.innerHTML = renderEmptyHtml('bell-slash', 'No active notices', 'No government or local notices are currently in effect.');
-                return;
-            }
+/**
+ * Render the provided notices list into the notices container.
+ * Shows an empty-state placeholder when the list is empty.
+ *
+ * @param {Array<Object>} notices - Notice records to render; each record
+ *   has at minimum: title, jurisdiction_type, jurisdiction, notice_type,
+ *   description, effective_time, affected_states, and optionally source_url
+ * @returns {void}
+ */
+function renderNotices(notices) {
+    const container = document.getElementById('noticesContainer');
+    if (notices.length === 0) {
+        container.innerHTML = renderEmptyHtml(
+            'bell-slash',
+            'No active notices',
+            'No government or local notices are currently in effect.'
+        );
+        return;
+    }
 
-            container.innerHTML = notices.map(notice => html`
+    container.innerHTML = notices
+        .map(
+            (notice) => html`
                 <div class="col-12 mb-3">
                     <div class="card">
                         <div class="card-header card-header-notice">
@@ -67,7 +72,8 @@
                             <div class="row">
                                 <div class="col-md-6">
                                     <small class="text-muted">
-                                        <i class="bi bi-calendar"></i> Effective: ${raw(formatDate(notice.effective_time))}
+                                        <i class="bi bi-calendar"></i> Effective:
+                                        ${raw(formatDate(notice.effective_time))}
                                     </small>
                                 </div>
                                 <div class="col-md-6">
@@ -76,31 +82,37 @@
                                     </small>
                                 </div>
                             </div>
-                            ${raw(notice.source_url ? `<a href="${escapeHtml(notice.source_url)}" target="_blank" class="btn btn-sm btn-outline-primary mt-2">View Source <i class="bi bi-box-arrow-up-right"></i></a>` : '')}
+                            ${raw(
+                                notice.source_url
+                                    ? `<a href="${escapeHtml(notice.source_url)}" target="_blank" class="btn btn-sm btn-outline-primary mt-2">View Source <i class="bi bi-box-arrow-up-right"></i></a>`
+                                    : ''
+                            )}
                         </div>
                     </div>
                 </div>
-            `).join('');
-        }
+            `
+        )
+        .join('');
+}
 
-        /**
-         * Filter the cached notice list by jurisdiction type and re-render.
-         * Filtering is performed client-side against the full allNotices array
-         * so no additional API call is needed when the dropdown changes.
-         *
-         * @returns {void}
-         */
-        function filterNotices() {
-            const jurisdiction = document.getElementById('jurisdictionFilter').value;
+/**
+ * Filter the cached notice list by jurisdiction type and re-render.
+ * Filtering is performed client-side against the full allNotices array
+ * so no additional API call is needed when the dropdown changes.
+ *
+ * @returns {void}
+ */
+function filterNotices() {
+    const jurisdiction = document.getElementById('jurisdictionFilter').value;
 
-            const filtered = allNotices.filter(notice => {
-                if (jurisdiction && notice.jurisdiction_type !== jurisdiction) return false;
-                return true;
-            });
+    const filtered = allNotices.filter((notice) => {
+        if (jurisdiction && notice.jurisdiction_type !== jurisdiction) return false;
+        return true;
+    });
 
-            renderNotices(filtered);
-        }
+    renderNotices(filtered);
+}
 
-        document.getElementById('jurisdictionFilter').addEventListener('change', filterNotices);
+document.getElementById('jurisdictionFilter').addEventListener('change', filterNotices);
 
-        loadNotices();
+loadNotices();

--- a/frontend/js/page-office-detail.js
+++ b/frontend/js/page-office-detail.js
@@ -1,328 +1,360 @@
-        /**
-         * page-office-detail.js
-         * Office detail page — loads a single office, its active advisories,
-         * and current weather observations; renders advisory cards with VTEC metadata.
-         *
-         * Key responsibilities:
-         *   - Reads the office code from the URL (?office= preferred, ?site= for legacy)
-         *   - Fetches all advisories, offices, and observations in parallel
-         *   - Aggregates and deduplicates advisories for the target office
-         *   - Renders: office header, highest alert card, impact summary, timeline,
-         *     and full advisory list with VTEC action badges and NWS external links
-         *   - Provides a modal detail view with full NOAA alert narrative
-         *
-         * State variables:
-         *   officeData       - The matched office record from the offices API
-         *   officeAdvisories - Raw advisory records for this office (pre-aggregation)
-         *
-         * External dependencies (globals):
-         *   API, OfficeAggregator, html, raw, escapeHtml, truncate, cToF, isStale,
-         *   timeAgo, formatDate, getSeverityBadge, getActionBadge, getActionBadgeWithTime,
-         *   renderEmptyHtml, renderErrorHtml — from utils.js / shared helpers
-         *   bootstrap (for modal instantiation)
-         */
+/**
+ * page-office-detail.js
+ * Office detail page — loads a single office, its active advisories,
+ * and current weather observations; renders advisory cards with VTEC metadata.
+ *
+ * Key responsibilities:
+ *   - Reads the office code from the URL (?office= preferred, ?site= for legacy)
+ *   - Fetches all advisories, offices, and observations in parallel
+ *   - Aggregates and deduplicates advisories for the target office
+ *   - Renders: office header, highest alert card, impact summary, timeline,
+ *     and full advisory list with VTEC action badges and NWS external links
+ *   - Provides a modal detail view with full NOAA alert narrative
+ *
+ * State variables:
+ *   officeData       - The matched office record from the offices API
+ *   officeAdvisories - Raw advisory records for this office (pre-aggregation)
+ *
+ * External dependencies (globals):
+ *   API, OfficeAggregator, html, raw, escapeHtml, truncate, cToF, isStale,
+ *   timeAgo, formatDate, getSeverityBadge, getActionBadge, getActionBadgeWithTime,
+ *   renderEmptyHtml, renderErrorHtml — from utils.js / shared helpers
+ *   bootstrap (for modal instantiation)
+ */
 
-        let officeData = null;
-        let officeAdvisories = [];
+let officeData = null;
+let officeAdvisories = [];
 
-        /**
-         * Main entry point — reads the office code from URL params, fetches all
-         * required data in parallel, matches the target office, and orchestrates
-         * the render sequence for each page section.
-         *
-         * URL parameter handling:
-         *   ?office=XXXXX  - preferred format (5-digit zip code)
-         *   ?site=XXXXX    - legacy alias retained for backwards compatibility
-         *                    with bookmarked or externally shared links
-         *
-         * @returns {Promise<void>}
-         */
-        async function loadOfficeDetail() {
-            try {
-                // Get office code from URL (?office= preferred, ?site= for legacy links)
-                const urlParams = new URLSearchParams(window.location.search);
-                const officeCode = urlParams.get('office') || urlParams.get('site');
+/**
+ * Main entry point — reads the office code from URL params, fetches all
+ * required data in parallel, matches the target office, and orchestrates
+ * the render sequence for each page section.
+ *
+ * URL parameter handling:
+ *   ?office=XXXXX  - preferred format (5-digit zip code)
+ *   ?site=XXXXX    - legacy alias retained for backwards compatibility
+ *                    with bookmarked or externally shared links
+ *
+ * @returns {Promise<void>}
+ */
+async function loadOfficeDetail() {
+    try {
+        // Get office code from URL (?office= preferred, ?site= for legacy links)
+        const urlParams = new URLSearchParams(window.location.search);
+        const officeCode = urlParams.get('office') || urlParams.get('site');
 
-                if (!officeCode) {
-                    showError('No office code provided in URL');
-                    return;
-                }
-
-                // Load all advisories, offices, and observations
-                const [allAdvisories, allOffices, obsData] = await Promise.all([
-                    API.getActiveAdvisories(),
-                    API.getOffices(),
-                    API.getObservations().catch(() => [])
-                ]);
-
-                // Find the office
-                officeData = allOffices.find(s => s.office_code === officeCode);
-                if (!officeData) {
-                    showError(`Office ${officeCode} not found`);
-                    return;
-                }
-
-                // Get advisories for this office
-                officeAdvisories = allAdvisories.filter(a => a.office_code === officeCode);
-
-                if (officeAdvisories.length === 0) {
-                    showError(`No active advisories for office ${officeCode}`);
-                    return;
-                }
-
-                // Aggregate with deduplication
-                const aggregated = OfficeAggregator.aggregateByOffice(officeAdvisories, { deduplicateZones: true });
-                const officeAggData = aggregated[0]; // Should only be one office
-
-                // Find observation for this office
-                const officeObs = obsData.find(o => o.office_code === officeCode) || null;
-
-                // Render the page
-                renderOfficeHeader(officeData, officeAggData, officeObs);
-                renderHighestAlert(officeAggData);
-                renderImpactSummary(officeAggData);
-                renderTimeline(officeAggData);
-                renderAllAdvisories(officeAggData);
-
-                // Show content, hide loading
-                document.getElementById('loadingState').classList.add('d-none');
-                document.getElementById('officeContent').classList.remove('d-none');
-
-            } catch (error) {
-                console.error('Error loading office detail:', error);
-                showError('Failed to load office details: ' + error.message);
-            }
+        if (!officeCode) {
+            showError('No office code provided in URL');
+            return;
         }
 
-        /**
-         * Display the error state panel with the provided message.
-         * Hides the loading spinner and the main content section so the page
-         * degrades gracefully when an office is not found or the API fails.
-         *
-         * @param {string} message - Human-readable error description
-         * @returns {void}
-         */
-        function showError(message) {
-            document.getElementById('errorMessage').textContent = message;
-            document.getElementById('loadingState').classList.add('d-none');
-            document.getElementById('errorState').classList.remove('d-none');
+        // Load all advisories, offices, and observations
+        const [allAdvisories, allOffices, obsData] = await Promise.all([
+            API.getActiveAdvisories(),
+            API.getOffices(),
+            API.getObservations().catch(() => [])
+        ]);
+
+        // Find the office
+        officeData = allOffices.find((s) => s.office_code === officeCode);
+        if (!officeData) {
+            showError(`Office ${officeCode} not found`);
+            return;
         }
 
-        /**
-         * Populate the office header card with identity, location, severity badge,
-         * and current temperature display.
-         *
-         * @param {Object}      office  - Office record from the offices API
-         * @param {Object}      aggData - Aggregated office data from OfficeAggregator
-         * @param {Object|null} obs     - Current weather observation for this office,
-         *                               or null if no observation is available
-         * @returns {void}
-         */
-        function renderOfficeHeader(office, aggData, obs) {
-            document.getElementById('officeCode').textContent = office.office_code;
-            document.getElementById('officeName').textContent = office.name;
-            document.getElementById('breadcrumbOffice').textContent = `${office.office_code} — ${office.name}`;
-            document.getElementById('officeLocation').textContent = `${office.city}, ${office.state}`;
+        // Get advisories for this office
+        officeAdvisories = allAdvisories.filter((a) => a.office_code === officeCode);
 
-            const severity = aggData.highest_severity;
-            const severityBadge = document.getElementById('highestSeverityBadge');
-            severityBadge.textContent = severity;
-            severityBadge.className = `badge severity-badge-large severity-${severity.toLowerCase()}`;
-
-            // Temperature display
-            const tempContainer = document.getElementById('officeTempDisplay');
-            const tempHtml = renderTemperatureHTML(obs);
-            if (tempHtml) {
-                tempContainer.innerHTML = tempHtml;
-            }
-
-            const headerCard = document.getElementById('officeHeaderCard');
-            headerCard.className = `card office-card office-card-${severity.toLowerCase()}`;
+        if (officeAdvisories.length === 0) {
+            showError(`No active advisories for office ${officeCode}`);
+            return;
         }
 
-        /**
-         * Extract the *WHAT... block from a NOAA alert description
-         * @param {string} description - Full alert description text
-         * @returns {string|null} The WHAT text, or null if not found
-         */
-        function extractWhat(description) {
-            if (!description) return null;
-            const match = description.match(/\* WHAT\.\.\.(.+?)(?=\n\n|\n\* |$)/s);
-            return match ? match[1].replace(/\s+/g, ' ').trim() : null;
-        }
+        // Aggregate with deduplication
+        const aggregated = OfficeAggregator.aggregateByOffice(officeAdvisories, { deduplicateZones: true });
+        const officeAggData = aggregated[0]; // Should only be one office
 
-        /**
-         * Extract the *WHEN... block from a NOAA alert description
-         * @param {string} description - Full alert description text
-         * @returns {string|null} The WHEN text, or null if not found
-         */
-        function extractWhen(description) {
-            if (!description) return null;
-            const match = description.match(/\* WHEN\.\.\.(.+?)(?=\n\n|\n\* |$)/s);
-            return match ? match[1].replace(/\s+/g, ' ').trim() : null;
-        }
+        // Find observation for this office
+        const officeObs = obsData.find((o) => o.office_code === officeCode) || null;
 
-        /**
-         * Render the "highest alert" hero card with the most severe active advisory.
-         * Extracts the WHAT and WHEN sections from the NOAA narrative for a quick
-         * plain-language summary without displaying the full multi-paragraph text.
-         *
-         * @param {Object} aggData - Aggregated office object from OfficeAggregator;
-         *                          must contain highest_severity_advisory
-         * @returns {void}
-         */
-        function renderHighestAlert(aggData) {
-            const advisory = aggData.highest_severity_advisory;
-            const card = document.getElementById('highestAlertCard');
-            const advisoryJson = JSON.stringify(advisory).replace(/'/g, '&#39;');
+        // Render the page
+        renderOfficeHeader(officeData, officeAggData, officeObs);
+        renderHighestAlert(officeAggData);
+        renderImpactSummary(officeAggData);
+        renderTimeline(officeAggData);
+        renderAllAdvisories(officeAggData);
 
-            const whatText = extractWhat(advisory.description);
-            const whenText = extractWhen(advisory.description);
+        // Show content, hide loading
+        document.getElementById('loadingState').classList.add('d-none');
+        document.getElementById('officeContent').classList.remove('d-none');
+    } catch (error) {
+        console.error('Error loading office detail:', error);
+        showError('Failed to load office details: ' + error.message);
+    }
+}
 
-            card.innerHTML = html`
-                <h5 class="card-title">${advisory.advisory_type}</h5>
-                <p class="card-text">
-                    ${raw(`<span class="badge ${getSeverityBadge(advisory.severity)}">${escapeHtml(advisory.severity)}</span>`)}
-                    ${raw(getActionBadgeWithTime(advisory))}
-                </p>
-                <p class="card-text">${advisory.headline || advisory.advisory_type}</p>
-                ${raw(whatText ? `<p class="card-text"><strong>What:</strong> ${escapeHtml(whatText)}</p>` : '')}
-                ${raw(whenText ? `<p class="card-text"><strong>When:</strong> ${escapeHtml(whenText)}</p>` : '')}
-                <p class="card-text">
-                    <strong>Issued:</strong> ${raw(formatDate(advisory.last_updated))}<br>
-                    <strong>Source:</strong> ${advisory.source}
-                </p>
-                <div class="mt-3">
-                    ${raw(`<button class="btn btn-sm btn-outline-info me-2 view-alert-btn" data-advisory='${advisoryJson}'>
+/**
+ * Display the error state panel with the provided message.
+ * Hides the loading spinner and the main content section so the page
+ * degrades gracefully when an office is not found or the API fails.
+ *
+ * @param {string} message - Human-readable error description
+ * @returns {void}
+ */
+function showError(message) {
+    document.getElementById('errorMessage').textContent = message;
+    document.getElementById('loadingState').classList.add('d-none');
+    document.getElementById('errorState').classList.remove('d-none');
+}
+
+/**
+ * Populate the office header card with identity, location, severity badge,
+ * and current temperature display.
+ *
+ * @param {Object}      office  - Office record from the offices API
+ * @param {Object}      aggData - Aggregated office data from OfficeAggregator
+ * @param {Object|null} obs     - Current weather observation for this office,
+ *                               or null if no observation is available
+ * @returns {void}
+ */
+function renderOfficeHeader(office, aggData, obs) {
+    document.getElementById('officeCode').textContent = office.office_code;
+    document.getElementById('officeName').textContent = office.name;
+    document.getElementById('breadcrumbOffice').textContent = `${office.office_code} — ${office.name}`;
+    document.getElementById('officeLocation').textContent = `${office.city}, ${office.state}`;
+
+    const severity = aggData.highest_severity;
+    const severityBadge = document.getElementById('highestSeverityBadge');
+    severityBadge.textContent = severity;
+    severityBadge.className = `badge severity-badge-large severity-${severity.toLowerCase()}`;
+
+    // Temperature display
+    const tempContainer = document.getElementById('officeTempDisplay');
+    const tempHtml = renderTemperatureHTML(obs);
+    if (tempHtml) {
+        tempContainer.innerHTML = tempHtml;
+    }
+
+    const headerCard = document.getElementById('officeHeaderCard');
+    headerCard.className = `card office-card office-card-${severity.toLowerCase()}`;
+}
+
+/**
+ * Extract the *WHAT... block from a NOAA alert description
+ * @param {string} description - Full alert description text
+ * @returns {string|null} The WHAT text, or null if not found
+ */
+function extractWhat(description) {
+    if (!description) return null;
+    const match = description.match(/\* WHAT\.\.\.(.+?)(?=\n\n|\n\* |$)/s);
+    return match ? match[1].replace(/\s+/g, ' ').trim() : null;
+}
+
+/**
+ * Extract the *WHEN... block from a NOAA alert description
+ * @param {string} description - Full alert description text
+ * @returns {string|null} The WHEN text, or null if not found
+ */
+function extractWhen(description) {
+    if (!description) return null;
+    const match = description.match(/\* WHEN\.\.\.(.+?)(?=\n\n|\n\* |$)/s);
+    return match ? match[1].replace(/\s+/g, ' ').trim() : null;
+}
+
+/**
+ * Render the "highest alert" hero card with the most severe active advisory.
+ * Extracts the WHAT and WHEN sections from the NOAA narrative for a quick
+ * plain-language summary without displaying the full multi-paragraph text.
+ *
+ * @param {Object} aggData - Aggregated office object from OfficeAggregator;
+ *                          must contain highest_severity_advisory
+ * @returns {void}
+ */
+function renderHighestAlert(aggData) {
+    const advisory = aggData.highest_severity_advisory;
+    const card = document.getElementById('highestAlertCard');
+    const advisoryJson = JSON.stringify(advisory).replace(/'/g, '&#39;');
+
+    const whatText = extractWhat(advisory.description);
+    const whenText = extractWhen(advisory.description);
+
+    card.innerHTML = html`
+        <h5 class="card-title">${advisory.advisory_type}</h5>
+        <p class="card-text">
+            ${raw(`<span class="badge ${getSeverityBadge(advisory.severity)}">${escapeHtml(advisory.severity)}</span>`)}
+            ${raw(getActionBadgeWithTime(advisory))}
+        </p>
+        <p class="card-text">${advisory.headline || advisory.advisory_type}</p>
+        ${raw(whatText ? `<p class="card-text"><strong>What:</strong> ${escapeHtml(whatText)}</p>` : '')}
+        ${raw(whenText ? `<p class="card-text"><strong>When:</strong> ${escapeHtml(whenText)}</p>` : '')}
+        <p class="card-text">
+            <strong>Issued:</strong> ${raw(formatDate(advisory.last_updated))}<br />
+            <strong>Source:</strong> ${advisory.source}
+        </p>
+        <div class="mt-3">
+            ${raw(`<button class="btn btn-sm btn-outline-info me-2 view-alert-btn" data-advisory='${advisoryJson}'>
                         <i class="bi bi-file-text"></i> View Full Alert
-                    </button>`)}
-                    ${raw(getExternalLinks(advisory))}
-                </div>
-            `;
-        }
+                    </button>`)} ${raw(getExternalLinks(advisory))}
+        </div>
+    `;
+}
 
-        /**
-         * Render the impact summary grid — one card per unique alert type showing
-         * severity, alert count, and (if applicable) the number of NWS forecast zones.
-         *
-         * @param {Object} aggData - Aggregated office object; must contain type_groups
-         * @returns {void}
-         */
-        function renderImpactSummary(aggData) {
-            const container = document.getElementById('impactSummaryContainer');
+/**
+ * Render the impact summary grid — one card per unique alert type showing
+ * severity, alert count, and (if applicable) the number of NWS forecast zones.
+ *
+ * @param {Object} aggData - Aggregated office object; must contain type_groups
+ * @returns {void}
+ */
+function renderImpactSummary(aggData) {
+    const container = document.getElementById('impactSummaryContainer');
 
-            const summary = aggData.type_groups.map(group => html`
+    const summary = aggData.type_groups
+        .map(
+            (group) => html`
                 <div class="col-md-6 col-lg-4 mb-3">
                     <div class="card static-card">
                         <div class="card-body">
                             <h6 class="card-title">${group.type}</h6>
                             <p class="mb-2">
-                                ${raw(`<span class="badge ${getSeverityBadge(group.severity)}">${escapeHtml(group.severity)}</span>`)}
+                                ${raw(
+                                    `<span class="badge ${getSeverityBadge(group.severity)}">${escapeHtml(group.severity)}</span>`
+                                )}
                             </p>
                             <p class="mb-0">
                                 <strong>${group.count}</strong> ${raw(group.count === 1 ? 'alert' : 'alerts')}
-                                ${raw(group.zone_count > 1 ?
-                                    `<span class="badge zone-badge zone-badge-multi ms-2">${group.zone_count} zones</span>` :
-                                    '')}
+                                ${raw(
+                                    group.zone_count > 1
+                                        ? `<span class="badge zone-badge zone-badge-multi ms-2">${group.zone_count} zones</span>`
+                                        : ''
+                                )}
                             </p>
                         </div>
                     </div>
                 </div>
-            `).join('');
+            `
+        )
+        .join('');
 
-            container.innerHTML = html`<div class="row">${raw(summary)}</div>`;
-        }
+    container.innerHTML = html`<div class="row">${raw(summary)}</div>`;
+}
 
-        /**
-         * Render the advisory timeline sorted newest-first.
-         * Each entry shows the alert type, VTEC action badge, severity, and a
-         * human-readable relative timestamp (e.g. "3 hours ago") alongside the
-         * formatted absolute date for auditability.
-         *
-         * @param {Object} aggData - Aggregated office object; must contain advisories array
-         * @returns {void}
-         */
-        function renderTimeline(aggData) {
-            const container = document.getElementById('timelineContainer');
+/**
+ * Render the advisory timeline sorted newest-first.
+ * Each entry shows the alert type, VTEC action badge, severity, and a
+ * human-readable relative timestamp (e.g. "3 hours ago") alongside the
+ * formatted absolute date for auditability.
+ *
+ * @param {Object} aggData - Aggregated office object; must contain advisories array
+ * @returns {void}
+ */
+function renderTimeline(aggData) {
+    const container = document.getElementById('timelineContainer');
 
-            // Sort advisories by last_updated
-            const sorted = [...aggData.advisories].sort((a, b) =>
-                new Date(b.last_updated) - new Date(a.last_updated)
-            );
+    // Sort advisories by last_updated
+    const sorted = [...aggData.advisories].sort((a, b) => new Date(b.last_updated) - new Date(a.last_updated));
 
-            const timeline = sorted.map((adv, index) => {
-                const hoursAgo = Math.round((new Date() - new Date(adv.last_updated)) / 3600000);
-                const timeText = hoursAgo < 1 ? 'Just now' :
-                                 hoursAgo === 1 ? '1 hour ago' :
-                                 hoursAgo < 24 ? `${hoursAgo} hours ago` :
-                                 `${Math.round(hoursAgo/24)} days ago`;
+    const timeline = sorted
+        .map((adv, index) => {
+            const hoursAgo = Math.round((new Date() - new Date(adv.last_updated)) / 3600000);
+            const timeText =
+                hoursAgo < 1
+                    ? 'Just now'
+                    : hoursAgo === 1
+                      ? '1 hour ago'
+                      : hoursAgo < 24
+                        ? `${hoursAgo} hours ago`
+                        : `${Math.round(hoursAgo / 24)} days ago`;
 
-                return html`
-                    <div class="timeline-item ${raw(index === 0 ? 'timeline-item-first' : '')}">
-                        <div class="timeline-marker"></div>
-                        <div class="timeline-content">
-                            <small class="text-muted">${raw(formatDate(adv.last_updated))} (${timeText})</small>
-                            <div>
-                                <strong>${adv.advisory_type}</strong>
-                                ${raw(getActionBadgeWithTime(adv))}
-                                ${raw(`<span class="badge ${getSeverityBadge(adv.severity)} ms-2">${escapeHtml(adv.severity)}</span>`)}
-                            </div>
+            return html`
+                <div class="timeline-item ${raw(index === 0 ? 'timeline-item-first' : '')}">
+                    <div class="timeline-marker"></div>
+                    <div class="timeline-content">
+                        <small class="text-muted">${raw(formatDate(adv.last_updated))} (${timeText})</small>
+                        <div>
+                            <strong>${adv.advisory_type}</strong>
+                            ${raw(getActionBadgeWithTime(adv))}
+                            ${raw(
+                                `<span class="badge ${getSeverityBadge(adv.severity)} ms-2">${escapeHtml(adv.severity)}</span>`
+                            )}
                         </div>
                     </div>
-                `;
-            }).join('');
+                </div>
+            `;
+        })
+        .join('');
 
-            container.innerHTML = timeline || '<p class="text-center text-muted py-3 mb-0"><i class="bi bi-clock-history me-1"></i>No timeline data available</p>';
-        }
+    container.innerHTML =
+        timeline ||
+        '<p class="text-center text-muted py-3 mb-0"><i class="bi bi-clock-history me-1"></i>No timeline data available</p>';
+}
 
-        /**
-         * Render the full advisory list grouped by alert type.
-         * Each group card includes action badges, zone counts, WHAT/WHEN summaries,
-         * a "View Full Alert" button that opens the detail modal, and NWS links.
-         * Groups are sourced from aggData.type_groups so zone-deduplicated counts
-         * are used rather than raw advisory rows.
-         *
-         * @param {Object} aggData - Aggregated office object; must contain
-         *                          type_groups and total_zone_count
-         * @returns {void}
-         */
-        function renderAllAdvisories(aggData) {
-            const container = document.getElementById('allAdvisoriesContainer');
-            document.getElementById('totalAdvisoryCount').textContent = aggData.total_zone_count;
+/**
+ * Render the full advisory list grouped by alert type.
+ * Each group card includes action badges, zone counts, WHAT/WHEN summaries,
+ * a "View Full Alert" button that opens the detail modal, and NWS links.
+ * Groups are sourced from aggData.type_groups so zone-deduplicated counts
+ * are used rather than raw advisory rows.
+ *
+ * @param {Object} aggData - Aggregated office object; must contain
+ *                          type_groups and total_zone_count
+ * @returns {void}
+ */
+function renderAllAdvisories(aggData) {
+    const container = document.getElementById('allAdvisoriesContainer');
+    document.getElementById('totalAdvisoryCount').textContent = aggData.total_zone_count;
 
-            const advisories = aggData.type_groups.map(group => {
-                // Escape the advisory data for use in data attribute
-                const advisoryJson = JSON.stringify(group.representative).replace(/'/g, '&#39;');
+    const advisories = aggData.type_groups
+        .map((group) => {
+            // Escape the advisory data for use in data attribute
+            const advisoryJson = JSON.stringify(group.representative).replace(/'/g, '&#39;');
 
-                return html`
+            return html`
                 <div class="col-12 mb-3">
                     <div class="card">
                         <div class="card-header">
                             <h6 class="mb-0">
                                 ${group.type}
-                                ${raw(`<span class="badge ${getSeverityBadge(group.severity)} float-end">${escapeHtml(group.severity)}</span>`)}
+                                ${raw(
+                                    `<span class="badge ${getSeverityBadge(group.severity)} float-end">${escapeHtml(group.severity)}</span>`
+                                )}
                             </h6>
                         </div>
                         <div class="card-body">
                             <p class="mb-2">
                                 ${raw(getActionBadgeWithTime(group.representative))}
-                                ${raw(group.zone_count > 1 ?
-                                    `<span class="badge zone-badge zone-badge-multi ms-2">
+                                ${raw(
+                                    group.zone_count > 1
+                                        ? `<span class="badge zone-badge zone-badge-multi ms-2">
                                         <i class="bi bi-layers"></i> ${group.zone_count} NWS zones
-                                    </span>` :
-                                    `<span class="badge zone-badge ms-2">${escapeHtml(group.representative.source)}</span>`)}
+                                    </span>`
+                                        : `<span class="badge zone-badge ms-2">${escapeHtml(group.representative.source)}</span>`
+                                )}
                             </p>
                             <p class="mb-1">${group.representative.headline || group.type}</p>
-                            ${raw((() => { const t = extractWhat(group.representative.description); return t ? `<p class="mb-1"><strong>What:</strong> ${escapeHtml(t)}</p>` : ''; })())}
-                            ${raw((() => { const w = extractWhen(group.representative.description); return w ? `<p class="mb-1"><strong>When:</strong> ${escapeHtml(w)}</p>` : ''; })())}
+                            ${raw(
+                                (() => {
+                                    const t = extractWhat(group.representative.description);
+                                    return t ? `<p class="mb-1"><strong>What:</strong> ${escapeHtml(t)}</p>` : '';
+                                })()
+                            )}
+                            ${raw(
+                                (() => {
+                                    const w = extractWhen(group.representative.description);
+                                    return w ? `<p class="mb-1"><strong>When:</strong> ${escapeHtml(w)}</p>` : '';
+                                })()
+                            )}
                             <p class="mb-1">
-                                <strong>Issued:</strong> ${raw(formatDate(group.representative.last_updated))}<br>
+                                <strong>Issued:</strong> ${raw(formatDate(group.representative.last_updated))}<br />
                                 <strong>Source:</strong> ${group.representative.source}
                             </p>
-                            ${raw(group.zone_count > 1 ?
-                                `<small class="text-muted d-block mb-2">
+                            ${raw(
+                                group.zone_count > 1
+                                    ? `<small class="text-muted d-block mb-2">
                                     This alert covers multiple NWS forecast zones for this location.
-                                </small>` : '')}
+                                </small>`
+                                    : ''
+                            )}
                             <div class="mt-2">
                                 ${raw(`<button class="btn btn-sm btn-outline-info me-2 view-alert-btn" data-advisory='${advisoryJson}'>
                                     <i class="bi bi-file-text"></i> View Full Alert
@@ -332,42 +364,44 @@
                         </div>
                     </div>
                 </div>
-            `}).join('');
+            `;
+        })
+        .join('');
 
-            container.innerHTML = html`<div class="row">${raw(advisories)}</div>`;
-        }
+    container.innerHTML = html`<div class="row">${raw(advisories)}</div>`;
+}
 
-        // getActionBadgeWithTime() is defined in js/utils.js
+// getActionBadgeWithTime() is defined in js/utils.js
 
-        /**
-         * Return a human-readable time-remaining string for an advisory expiry.
-         *
-         * @param {string} expiresISO - ISO 8601 expiry datetime string
-         * @returns {string} e.g. "Expired", "Expires soon", "3 hours remaining",
-         *                   "2 days remaining"
-         */
-        function getTimeRemaining(expiresISO) {
-            const hours = Math.round((new Date(expiresISO) - new Date()) / 3600000);
-            if (hours < 0) return 'Expired';
-            if (hours < 1) return 'Expires soon';
-            if (hours === 1) return '1 hour remaining';
-            if (hours < 24) return `${hours} hours remaining`;
-            const days = Math.round(hours / 24);
-            return days === 1 ? '1 day remaining' : `${days} days remaining`;
-        }
+/**
+ * Return a human-readable time-remaining string for an advisory expiry.
+ *
+ * @param {string} expiresISO - ISO 8601 expiry datetime string
+ * @returns {string} e.g. "Expired", "Expires soon", "3 hours remaining",
+ *                   "2 days remaining"
+ */
+function getTimeRemaining(expiresISO) {
+    const hours = Math.round((new Date(expiresISO) - new Date()) / 3600000);
+    if (hours < 0) return 'Expired';
+    if (hours < 1) return 'Expires soon';
+    if (hours === 1) return '1 hour remaining';
+    if (hours < 24) return `${hours} hours remaining`;
+    const days = Math.round(hours / 24);
+    return days === 1 ? '1 day remaining' : `${days} days remaining`;
+}
 
-        /**
-         * Generate external links for NOAA official alert and map
-         * @param {Object} advisory - Advisory object with external_id and source
-         * @returns {string} HTML for external link buttons
-         */
-        function getExternalLinks(advisory) {
-            const links = [];
+/**
+ * Generate external links for NOAA official alert and map
+ * @param {Object} advisory - Advisory object with external_id and source
+ * @returns {string} HTML for external link buttons
+ */
+function getExternalLinks(advisory) {
+    const links = [];
 
-            // NWS office homepage (shows local forecasts, alerts, and radar for the region)
-            if (officeData && officeData.cwa) {
-                const nwsUrl = `https://www.weather.gov/${officeData.cwa.toLowerCase()}`;
-                links.push(`
+    // NWS office homepage (shows local forecasts, alerts, and radar for the region)
+    if (officeData && officeData.cwa) {
+        const nwsUrl = `https://www.weather.gov/${officeData.cwa.toLowerCase()}`;
+        links.push(`
                     <a href="${nwsUrl}"
                        target="_blank"
                        rel="noopener noreferrer"
@@ -376,10 +410,10 @@
                         <i class="bi bi-cloud-sun"></i> NWS Forecast
                     </a>
                 `);
-            }
+    }
 
-            // National radar map
-            links.push(`
+    // National radar map
+    links.push(`
                 <a href="https://radar.weather.gov/"
                    target="_blank"
                    rel="noopener noreferrer"
@@ -389,97 +423,103 @@
                 </a>
             `);
 
-            return links.join('');
-        }
+    return links.join('');
+}
 
-        /**
-         * Show alert detail modal with full narrative
-         * @param {Object} advisory - Advisory object with description
-         */
-        function showAlertDetail(advisory) {
-            const modalLabel = document.getElementById('alertDetailModalLabel');
-            const modalBody = document.getElementById('alertDetailModalBody');
-            const modalLinks = document.getElementById('alertDetailModalLinks');
+/**
+ * Show alert detail modal with full narrative
+ * @param {Object} advisory - Advisory object with description
+ */
+function showAlertDetail(advisory) {
+    const modalLabel = document.getElementById('alertDetailModalLabel');
+    const modalBody = document.getElementById('alertDetailModalBody');
+    const modalLinks = document.getElementById('alertDetailModalLinks');
 
-            // Set title - escape advisory type and severity
-            modalLabel.innerHTML = html`
-                ${advisory.advisory_type}
-                ${raw(`<span class="badge ${getSeverityBadge(advisory.severity)} ms-2">${escapeHtml(advisory.severity)}</span>`)}
-            `;
+    // Set title - escape advisory type and severity
+    modalLabel.innerHTML = html`
+        ${advisory.advisory_type}
+        ${raw(
+            `<span class="badge ${getSeverityBadge(advisory.severity)} ms-2">${escapeHtml(advisory.severity)}</span>`
+        )}
+    `;
 
-            // Format description - escape first, then apply formatting
-            // This prevents XSS while preserving NOAA's text structure
-            const safeDescription = advisory.description
-                ? escapeHtml(advisory.description)
-                    .replace(/\n\n/g, '</p><p>')
-                    .replace(/\n\*/g, '</p><p class="mb-1"><strong>*')
-                    .replace(/\.\.\./g, '...</strong>')
-                    .replace(/\n/g, '<br>')
-                : '<em>No detailed description available</em>';
+    // Format description - escape first, then apply formatting
+    // This prevents XSS while preserving NOAA's text structure
+    const safeDescription = advisory.description
+        ? escapeHtml(advisory.description)
+              .replace(/\n\n/g, '</p><p>')
+              .replace(/\n\*/g, '</p><p class="mb-1"><strong>*')
+              .replace(/\.\.\./g, '...</strong>')
+              .replace(/\n/g, '<br>')
+        : '<em>No detailed description available</em>';
 
-            // Build modal body with escaped content
-            modalBody.innerHTML = html`
-                <div class="mb-3">
-                    <h6 class="text-muted">Headline</h6>
-                    <p class="lead">${advisory.headline || advisory.advisory_type}</p>
+    // Build modal body with escaped content
+    modalBody.innerHTML = html`
+        <div class="mb-3">
+            <h6 class="text-muted">Headline</h6>
+            <p class="lead">${advisory.headline || advisory.advisory_type}</p>
+        </div>
+
+        <div class="mb-3">
+            <div class="row">
+                <div class="col-sm-6"><strong>Status:</strong> ${raw(getActionBadgeWithTime(advisory))}</div>
+                <div class="col-sm-6"><strong>Source:</strong> ${advisory.source || 'NOAA/NWS'}</div>
+            </div>
+        </div>
+
+        <div class="mb-3">
+            <div class="row">
+                <div class="col-sm-6">
+                    <strong>Issued:</strong> ${raw(formatDate(advisory.last_updated || advisory.issued_time))}
                 </div>
-
-                <div class="mb-3">
-                    <div class="row">
-                        <div class="col-sm-6">
-                            <strong>Status:</strong> ${raw(getActionBadgeWithTime(advisory))}
-                        </div>
-                        <div class="col-sm-6">
-                            <strong>Source:</strong> ${advisory.source || 'NOAA/NWS'}
-                        </div>
-                    </div>
+                <div class="col-sm-6">
+                    <strong>Expires:</strong> ${raw(
+                        advisory.expires
+                            ? formatDate(advisory.expires) + ' (' + getTimeRemaining(advisory.expires) + ')'
+                            : 'Unknown'
+                    )}
                 </div>
+            </div>
+        </div>
 
-                <div class="mb-3">
-                    <div class="row">
-                        <div class="col-sm-6">
-                            <strong>Issued:</strong> ${raw(formatDate(advisory.last_updated || advisory.issued_time))}
-                        </div>
-                        <div class="col-sm-6">
-                            <strong>Expires:</strong> ${raw(advisory.expires ? formatDate(advisory.expires) + ' (' + getTimeRemaining(advisory.expires) + ')' : 'Unknown')}
-                        </div>
-                    </div>
-                </div>
+        <hr />
 
-                <hr>
+        <div class="mb-3">
+            <h6 class="text-muted">Full Alert Details</h6>
+            <div class="alert-description bg-light p-3 rounded" style="white-space: pre-line; font-family: inherit;">
+                <p>${raw(safeDescription)}</p>
+            </div>
+        </div>
 
-                <div class="mb-3">
-                    <h6 class="text-muted">Full Alert Details</h6>
-                    <div class="alert-description bg-light p-3 rounded" style="white-space: pre-line; font-family: inherit;">
-                        <p>${raw(safeDescription)}</p>
-                    </div>
-                </div>
-
-                ${raw(advisory.vtec_code ? `
+        ${raw(
+            advisory.vtec_code
+                ? `
                 <div class="mb-0">
                     <small class="text-muted">
                         <strong>VTEC:</strong> <code>${escapeHtml(advisory.vtec_code)}</code>
                     </small>
                 </div>
-                ` : '')}
-            `;
+                `
+                : ''
+        )}
+    `;
 
-            // Set external links in footer
-            modalLinks.innerHTML = getExternalLinks(advisory);
+    // Set external links in footer
+    modalLinks.innerHTML = getExternalLinks(advisory);
 
-            // Show modal
-            const modal = new bootstrap.Modal(document.getElementById('alertDetailModal'));
-            modal.show();
-        }
+    // Show modal
+    const modal = new bootstrap.Modal(document.getElementById('alertDetailModal'));
+    modal.show();
+}
 
-        // Event delegation for View Full Alert buttons
-        document.addEventListener('click', function(e) {
-            const btn = e.target.closest('.view-alert-btn');
-            if (btn && btn.dataset.advisory) {
-                const advisory = JSON.parse(btn.dataset.advisory);
-                showAlertDetail(advisory);
-            }
-        });
+// Event delegation for View Full Alert buttons
+document.addEventListener('click', function (e) {
+    const btn = e.target.closest('.view-alert-btn');
+    if (btn && btn.dataset.advisory) {
+        const advisory = JSON.parse(btn.dataset.advisory);
+        showAlertDetail(advisory);
+    }
+});
 
-        // Initialize
-        loadOfficeDetail();
+// Initialize
+loadOfficeDetail();

--- a/frontend/js/page-offices.js
+++ b/frontend/js/page-offices.js
@@ -1,156 +1,164 @@
-        /**
-         * page-offices.js
-         * Offices page — loads all office locations, applies advisory data
-         * and weather observations, renders a filterable sortable card grid.
-         *
-         * Key responsibilities:
-         *   - Fetches offices, active advisories, and weather observations in parallel
-         *   - Applies user-configured alert-type filters (AlertFilters) and aggregates
-         *     advisory counts/severity per office via OfficeAggregator
-         *   - Only displays offices that have at least one advisory after filtering
-         *   - Supports free-text search, state, weather-impact-level, and status filters
-         *   - Handles ?office=, ?site= (legacy), and ?weather_impact= URL parameters
-         *     to pre-populate filter controls from external links (e.g. dashboard)
-         *
-         * State variables:
-         *   allOffices      - All offices from the API (unfiltered)
-         *   allAdvisories   - All active advisories (unfiltered); re-filtered each render
-         *   observationsMap - Keyed by office_code; provides current temperature readings
-         *
-         * External dependencies (globals):
-         *   API, AlertFilters, OfficeAggregator, debounce, html, raw, escapeHtml,
-         *   truncate, cToF, isStale, timeAgo, formatDate, renderEmptyHtml, renderErrorHtml
-         */
+/**
+ * page-offices.js
+ * Offices page — loads all office locations, applies advisory data
+ * and weather observations, renders a filterable sortable card grid.
+ *
+ * Key responsibilities:
+ *   - Fetches offices, active advisories, and weather observations in parallel
+ *   - Applies user-configured alert-type filters (AlertFilters) and aggregates
+ *     advisory counts/severity per office via OfficeAggregator
+ *   - Only displays offices that have at least one advisory after filtering
+ *   - Supports free-text search, state, weather-impact-level, and status filters
+ *   - Handles ?office=, ?site= (legacy), and ?weather_impact= URL parameters
+ *     to pre-populate filter controls from external links (e.g. dashboard)
+ *
+ * State variables:
+ *   allOffices      - All offices from the API (unfiltered)
+ *   allAdvisories   - All active advisories (unfiltered); re-filtered each render
+ *   observationsMap - Keyed by office_code; provides current temperature readings
+ *
+ * External dependencies (globals):
+ *   API, AlertFilters, OfficeAggregator, debounce, html, raw, escapeHtml,
+ *   truncate, cToF, isStale, timeAgo, formatDate, renderEmptyHtml, renderErrorHtml
+ */
 
-        let allOffices = [];
-        let allAdvisories = [];
-        let observationsMap = {};
+let allOffices = [];
+let allAdvisories = [];
+let observationsMap = {};
 
-        /**
-         * Fetch all offices, active advisories, and weather observations in parallel,
-         * then apply filters and render the initial view.
-         * Promise.all is used so all three requests run concurrently — at 300 offices
-         * sequential fetching would take 3× as long. Observation failures are caught
-         * inline so the page still loads when the observations endpoint is unavailable.
-         *
-         * @returns {Promise<void>}
-         */
-        async function loadOffices() {
-            try {
-                // Load all offices, advisories, and observations
-                const [offices, advisories, obsData] = await Promise.all([
-                    API.getOffices(),
-                    API.getActiveAdvisories(),
-                    API.getObservations().catch(() => [])
-                ]);
+/**
+ * Fetch all offices, active advisories, and weather observations in parallel,
+ * then apply filters and render the initial view.
+ * Promise.all is used so all three requests run concurrently — at 300 offices
+ * sequential fetching would take 3× as long. Observation failures are caught
+ * inline so the page still loads when the observations endpoint is unavailable.
+ *
+ * @returns {Promise<void>}
+ */
+async function loadOffices() {
+    try {
+        // Load all offices, advisories, and observations
+        const [offices, advisories, obsData] = await Promise.all([
+            API.getOffices(),
+            API.getActiveAdvisories(),
+            API.getObservations().catch(() => [])
+        ]);
 
-                // Build observations lookup by office_code
-                observationsMap = {};
-                obsData.forEach(obs => { observationsMap[obs.office_code] = obs; });
+        // Build observations lookup by office_code
+        observationsMap = {};
+        obsData.forEach((obs) => {
+            observationsMap[obs.office_code] = obs;
+        });
 
-                allOffices = offices;
-                allAdvisories = advisories;
+        allOffices = offices;
+        allAdvisories = advisories;
 
-                // Apply filters and recalculate advisory counts
-                // This will filter to only show offices WITH advisories
-                const filteredData = applyFiltersToOffices(offices, advisories);
-                renderOffices(filteredData);
+        // Apply filters and recalculate advisory counts
+        // This will filter to only show offices WITH advisories
+        const filteredData = applyFiltersToOffices(offices, advisories);
+        renderOffices(filteredData);
 
-                // Populate state filter
-                const states = [...new Set(filteredData.map(s => s.state))].sort();
-                const stateSelect = document.getElementById('stateFilter');
-                states.forEach(state => {
-                    const option = document.createElement('option');
-                    option.value = state;
-                    option.textContent = state;
-                    stateSelect.appendChild(option);
-                });
-            } catch (error) {
-                document.getElementById('officesContainer').innerHTML =
-                    renderErrorHtml('Failed to load impacted offices');
-            }
-        }
+        // Populate state filter
+        const states = [...new Set(filteredData.map((s) => s.state))].sort();
+        const stateSelect = document.getElementById('stateFilter');
+        states.forEach((state) => {
+            const option = document.createElement('option');
+            option.value = state;
+            option.textContent = state;
+            stateSelect.appendChild(option);
+        });
+    } catch (error) {
+        document.getElementById('officesContainer').innerHTML = renderErrorHtml('Failed to load impacted offices');
+    }
+}
 
-        /**
-         * Apply the user's AlertFilters preferences to the advisory list, aggregate
-         * by office, and join the results back onto the base office records.
-         * Offices without any surviving advisories after filtering are omitted so
-         * the rendered list always reflects the "offices under advisory" view.
-         *
-         * @param {Array<Object>} offices   - All office records from the API
-         * @param {Array<Object>} advisories - All active advisories (unfiltered by UI)
-         * @returns {Array<Object>} Office records enriched with advisory_count,
-         *                         highest_severity, weather_impact_level, etc.
-         *                         Only offices with at least one surviving advisory
-         *                         are returned.
-         */
-        function applyFiltersToOffices(offices, advisories) {
-            // Filter advisories based on user preferences
-            const filteredAdvisories = AlertFilters.filterAdvisories(advisories);
+/**
+ * Apply the user's AlertFilters preferences to the advisory list, aggregate
+ * by office, and join the results back onto the base office records.
+ * Offices without any surviving advisories after filtering are omitted so
+ * the rendered list always reflects the "offices under advisory" view.
+ *
+ * @param {Array<Object>} offices   - All office records from the API
+ * @param {Array<Object>} advisories - All active advisories (unfiltered by UI)
+ * @returns {Array<Object>} Office records enriched with advisory_count,
+ *                         highest_severity, weather_impact_level, etc.
+ *                         Only offices with at least one surviving advisory
+ *                         are returned.
+ */
+function applyFiltersToOffices(offices, advisories) {
+    // Filter advisories based on user preferences
+    const filteredAdvisories = AlertFilters.filterAdvisories(advisories);
 
-            // Aggregate advisories by office with deduplication
-            const aggregatedOffices = OfficeAggregator.aggregateByOffice(filteredAdvisories, { deduplicateZones: true });
+    // Aggregate advisories by office with deduplication
+    const aggregatedOffices = OfficeAggregator.aggregateByOffice(filteredAdvisories, { deduplicateZones: true });
 
-            // Create map for quick lookup
-            const aggMap = new Map();
-            aggregatedOffices.forEach(office => {
-                aggMap.set(office.office_id, office);
-            });
+    // Create map for quick lookup
+    const aggMap = new Map();
+    aggregatedOffices.forEach((office) => {
+        aggMap.set(office.office_id, office);
+    });
 
-            // Map severity to weather impact level (matches dashboard)
-            const severityToImpact = { 'Extreme': 'red', 'Severe': 'orange', 'Moderate': 'yellow', 'Minor': 'green' };
+    // Map severity to weather impact level (matches dashboard)
+    const severityToImpact = { Extreme: 'red', Severe: 'orange', Moderate: 'yellow', Minor: 'green' };
 
-            // Enhance original offices with aggregation data
-            // Note: Offices API uses 'id', advisories use 'office_id'
-            return offices
-                .map(office => {
-                    const aggData = aggMap.get(office.id);
-                    if (!aggData) return null;
+    // Enhance original offices with aggregation data
+    // Note: Offices API uses 'id', advisories use 'office_id'
+    return offices
+        .map((office) => {
+            const aggData = aggMap.get(office.id);
+            if (!aggData) return null;
 
-                    return {
-                        ...office,
-                        advisory_count: aggData.unique_advisory_count,
-                        highest_severity: aggData.highest_severity,
-                        highest_severity_advisory: aggData.highest_severity_advisory,
-                        new_count: aggData.new_count,
-                        total_zone_count: aggData.total_zone_count,
-                        weather_impact_level: severityToImpact[aggData.highest_severity] || 'green'
-                    };
-                })
-                .filter(office => office !== null); // Remove offices without advisories
-        }
+            return {
+                ...office,
+                advisory_count: aggData.unique_advisory_count,
+                highest_severity: aggData.highest_severity,
+                highest_severity_advisory: aggData.highest_severity_advisory,
+                new_count: aggData.new_count,
+                total_zone_count: aggData.total_zone_count,
+                weather_impact_level: severityToImpact[aggData.highest_severity] || 'green'
+            };
+        })
+        .filter((office) => office !== null); // Remove offices without advisories
+}
 
-        /**
-         * Render the office card grid from the provided list.
-         * Offices are sorted highest-severity-first so the most critical locations
-         * appear at the top regardless of their alphabetical order.
-         *
-         * @param {Array<Object>} offices - Enriched office objects (from applyFiltersToOffices)
-         * @returns {void}
-         */
-        function renderOffices(offices) {
-            const container = document.getElementById('officesContainer');
-            if (offices.length === 0) {
-                container.innerHTML = renderEmptyHtml('building', 'No offices currently impacted', 'No monitored locations are affected by active weather advisories.');
-                return;
-            }
+/**
+ * Render the office card grid from the provided list.
+ * Offices are sorted highest-severity-first so the most critical locations
+ * appear at the top regardless of their alphabetical order.
+ *
+ * @param {Array<Object>} offices - Enriched office objects (from applyFiltersToOffices)
+ * @returns {void}
+ */
+function renderOffices(offices) {
+    const container = document.getElementById('officesContainer');
+    if (offices.length === 0) {
+        container.innerHTML = renderEmptyHtml(
+            'building',
+            'No offices currently impacted',
+            'No monitored locations are affected by active weather advisories.'
+        );
+        return;
+    }
 
-            // Sort by urgency (offices with highest severity first)
-            const sortedOffices = [...offices].sort((a, b) => {
-                const rankA = OfficeAggregator.getSeverityRank(a.highest_severity || 'Minor');
-                const rankB = OfficeAggregator.getSeverityRank(b.highest_severity || 'Minor');
-                return rankB - rankA;
-            });
+    // Sort by urgency (offices with highest severity first)
+    const sortedOffices = [...offices].sort((a, b) => {
+        const rankA = OfficeAggregator.getSeverityRank(a.highest_severity || 'Minor');
+        const rankB = OfficeAggregator.getSeverityRank(b.highest_severity || 'Minor');
+        return rankB - rankA;
+    });
 
-            container.innerHTML = sortedOffices.map(office => {
-                const severityClass = office.highest_severity ? `office-card-${escapeHtml(office.highest_severity.toLowerCase())}` : '';
-                const advisory = office.highest_severity_advisory;
-                const headlineText = advisory ? truncate(advisory.headline || '', 120) : '';
-                const obs = observationsMap[office.office_code];
+    container.innerHTML = sortedOffices
+        .map((office) => {
+            const severityClass = office.highest_severity
+                ? `office-card-${escapeHtml(office.highest_severity.toLowerCase())}`
+                : '';
+            const advisory = office.highest_severity_advisory;
+            const headlineText = advisory ? truncate(advisory.headline || '', 120) : '';
+            const obs = observationsMap[office.office_code];
 
-                const tempHtml = renderTemperatureHTML(obs);
+            const tempHtml = renderTemperatureHTML(obs);
 
-                return html`
+            return html`
                 <div class="col-md-6 col-lg-4 mb-3">
                     <a href="office-detail.html?office=${office.office_code}" class="text-decoration-none">
                         <div class="card office-card card-clickable ${raw(severityClass)}">
@@ -160,137 +168,166 @@
                                         <h5 class="card-title mb-0 text-dark">
                                             <strong>${office.office_code}</strong> - ${office.name}
                                         </h5>
-                                        <small class="text-muted"><i class="bi bi-geo-alt"></i> ${office.city}, ${office.state}</small>
+                                        <small class="text-muted"
+                                            ><i class="bi bi-geo-alt"></i> ${office.city}, ${office.state}</small
+                                        >
                                     </div>
                                     <div style="text-align: right;">
-                                        ${raw(office.highest_severity ?
-                                            `<span class="badge severity-badge severity-${escapeHtml(office.highest_severity.toLowerCase())}">
+                                        ${raw(
+                                            office.highest_severity
+                                                ? `<span class="badge severity-badge severity-${escapeHtml(office.highest_severity.toLowerCase())}">
                                                 ${escapeHtml(office.highest_severity)}
-                                            </span>` : '')}
+                                            </span>`
+                                                : ''
+                                        )}
                                         ${raw(tempHtml)}
                                     </div>
                                 </div>
 
-                                ${raw(advisory ? `
+                                ${raw(
+                                    advisory
+                                        ? `
                                 <div class="mb-2">
                                     <strong class="text-severity-${escapeHtml((advisory.severity || 'extreme').toLowerCase())}">${escapeHtml(advisory.advisory_type)}</strong>
                                     ${advisory.vtec_action === 'NEW' ? '<span class="badge action-badge-new ms-1"><i class="bi bi-bell-fill"></i> NEW</span>' : ''}
                                     ${headlineText ? '<br><small class="text-muted" style="line-height: 1.3; display: inline-block; margin-top: 0.25rem;">' + escapeHtml(headlineText) + '</small>' : ''}
                                 </div>
-                                ` : '')}
+                                `
+                                        : ''
+                                )}
 
                                 <p class="card-text text-dark">
-                                    <i class="bi bi-exclamation-triangle"></i> <strong>${office.advisory_count}</strong> active ${raw(office.advisory_count === 1 ? 'alert' : 'alerts')}
-                                    ${raw(office.total_zone_count !== office.advisory_count ?
-                                        `<span class="text-muted small">(${office.total_zone_count} zones)</span>` : '')}
-                                    ${raw(office.new_count > 0 ? `<br><i class="bi bi-bell"></i> <strong>${office.new_count}</strong> new` : '')}
+                                    <i class="bi bi-exclamation-triangle"></i>
+                                    <strong>${office.advisory_count}</strong> active
+                                    ${raw(office.advisory_count === 1 ? 'alert' : 'alerts')}
+                                    ${raw(
+                                        office.total_zone_count !== office.advisory_count
+                                            ? `<span class="text-muted small">(${office.total_zone_count} zones)</span>`
+                                            : ''
+                                    )}
+                                    ${raw(
+                                        office.new_count > 0
+                                            ? `<br><i class="bi bi-bell"></i> <strong>${office.new_count}</strong> new`
+                                            : ''
+                                    )}
                                 </p>
                             </div>
                         </div>
                     </a>
                 </div>
-                `;
-            }).join('');
-        }
+            `;
+        })
+        .join('');
+}
 
-        /**
-         * Re-apply both alert-type filters and UI filters, then re-render.
-         * Alert-type filtering runs first (applyFiltersToOffices) so advisory counts
-         * are always computed from the user's saved preferences; UI filters (search,
-         * state, weather impact, status) are applied as a second pass on the result.
-         *
-         * @returns {void}
-         */
-        function filterOffices() {
-            const search = document.getElementById('searchBox').value.toLowerCase();
-            const state = document.getElementById('stateFilter').value;
-            const weatherImpact = document.getElementById('weatherImpactFilter').value;
-            const status = document.getElementById('statusFilter').value;
+/**
+ * Re-apply both alert-type filters and UI filters, then re-render.
+ * Alert-type filtering runs first (applyFiltersToOffices) so advisory counts
+ * are always computed from the user's saved preferences; UI filters (search,
+ * state, weather impact, status) are applied as a second pass on the result.
+ *
+ * @returns {void}
+ */
+function filterOffices() {
+    const search = document.getElementById('searchBox').value.toLowerCase();
+    const state = document.getElementById('stateFilter').value;
+    const weatherImpact = document.getElementById('weatherImpactFilter').value;
+    const status = document.getElementById('statusFilter').value;
 
-            // First apply alert type filters to get updated advisory counts
-            const filteredData = applyFiltersToOffices(allOffices, allAdvisories);
+    // First apply alert type filters to get updated advisory counts
+    const filteredData = applyFiltersToOffices(allOffices, allAdvisories);
 
-            // Then apply UI filters
-            const filtered = filteredData.filter(office => {
-                if (search && !(office.office_code.toLowerCase().includes(search) || office.name.toLowerCase().includes(search))) return false;
-                if (state && office.state !== state) return false;
-                if (weatherImpact && office.weather_impact_level !== weatherImpact) return false;
-                if (status && office.operational_status !== status) return false;
-                return true;
-            });
+    // Then apply UI filters
+    const filtered = filteredData.filter((office) => {
+        if (
+            search &&
+            !(office.office_code.toLowerCase().includes(search) || office.name.toLowerCase().includes(search))
+        )
+            return false;
+        if (state && office.state !== state) return false;
+        if (weatherImpact && office.weather_impact_level !== weatherImpact) return false;
+        if (status && office.operational_status !== status) return false;
+        return true;
+    });
 
-            renderOffices(filtered);
-        }
+    renderOffices(filtered);
+}
 
-        /**
-         * Clear the weather-impact filter, hide the active-filter banner, remove the
-         * query parameter from the URL (without a page reload), and re-render.
-         * Called by the "Clear Filter" button in the active-filter banner that appears
-         * when the page is reached via a ?weather_impact= deep-link.
-         *
-         * @returns {void}
-         */
-        function clearWeatherFilter() {
-            document.getElementById('weatherImpactFilter').value = '';
-            document.getElementById('activeFilterBanner').classList.add('d-none');
-            // Update URL without the parameter
-            const url = new URL(window.location);
-            url.searchParams.delete('weather_impact');
-            window.history.replaceState({}, '', url);
-            filterOffices();
-        }
+/**
+ * Clear the weather-impact filter, hide the active-filter banner, remove the
+ * query parameter from the URL (without a page reload), and re-render.
+ * Called by the "Clear Filter" button in the active-filter banner that appears
+ * when the page is reached via a ?weather_impact= deep-link.
+ *
+ * @returns {void}
+ */
+function clearWeatherFilter() {
+    document.getElementById('weatherImpactFilter').value = '';
+    document.getElementById('activeFilterBanner').classList.add('d-none');
+    // Update URL without the parameter
+    const url = new URL(window.location);
+    url.searchParams.delete('weather_impact');
+    window.history.replaceState({}, '', url);
+    filterOffices();
+}
 
-        // 300ms debounce on search: avoids re-rendering on every keystroke during
-        // fast typing while still feeling responsive.
-        document.getElementById('searchBox').addEventListener('input', debounce(filterOffices, 300));
-        document.getElementById('stateFilter').addEventListener('change', filterOffices);
-        document.getElementById('weatherImpactFilter').addEventListener('change', function() {
-            // Hide banner when manually changing filter
-            if (!this.value) {
-                document.getElementById('activeFilterBanner').classList.add('d-none');
-            }
-            filterOffices();
-        });
-        document.getElementById('statusFilter').addEventListener('change', filterOffices);
-        document.getElementById('clearFilterBtn').addEventListener('click', clearWeatherFilter);
+// 300ms debounce on search: avoids re-rendering on every keystroke during
+// fast typing while still feeling responsive.
+document.getElementById('searchBox').addEventListener('input', debounce(filterOffices, 300));
+document.getElementById('stateFilter').addEventListener('change', filterOffices);
+document.getElementById('weatherImpactFilter').addEventListener('change', function () {
+    // Hide banner when manually changing filter
+    if (!this.value) {
+        document.getElementById('activeFilterBanner').classList.add('d-none');
+    }
+    filterOffices();
+});
+document.getElementById('statusFilter').addEventListener('change', filterOffices);
+document.getElementById('clearFilterBtn').addEventListener('click', clearWeatherFilter);
 
-        /**
-         * Read URL query parameters and pre-populate filter controls.
-         * Supports:
-         *   ?office=      - Pre-fill the search box with an office code
-         *   ?site=        - Legacy alias for ?office= (legacy alias)
-         *   ?weather_impact= - Pre-select the weather-impact dropdown and show the
-         *                       active-filter banner so users know filtering is active
-         *
-         * @returns {void}
-         */
-        function applyURLParameters() {
-            const urlParams = new URLSearchParams(window.location.search);
-            const officeParam = urlParams.get('office') || urlParams.get('site'); // support legacy ?site= links
-            const weatherImpactParam = urlParams.get('weather_impact');
+/**
+ * Read URL query parameters and pre-populate filter controls.
+ * Supports:
+ *   ?office=      - Pre-fill the search box with an office code
+ *   ?site=        - Legacy alias for ?office= (legacy alias)
+ *   ?weather_impact= - Pre-select the weather-impact dropdown and show the
+ *                       active-filter banner so users know filtering is active
+ *
+ * @returns {void}
+ */
+function applyURLParameters() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const officeParam = urlParams.get('office') || urlParams.get('site'); // support legacy ?site= links
+    const weatherImpactParam = urlParams.get('weather_impact');
 
-            if (officeParam) {
-                // Auto-populate search box with office code from URL
-                document.getElementById('searchBox').value = officeParam;
-            }
+    if (officeParam) {
+        // Auto-populate search box with office code from URL
+        document.getElementById('searchBox').value = officeParam;
+    }
 
-            if (weatherImpactParam) {
-                // Set weather impact filter from URL
-                document.getElementById('weatherImpactFilter').value = weatherImpactParam;
+    if (weatherImpactParam) {
+        // Set weather impact filter from URL
+        document.getElementById('weatherImpactFilter').value = weatherImpactParam;
 
-                // Show active filter banner
-                const labels = { red: 'Extreme (High Impact)', orange: 'Severe (Severe Impact)', yellow: 'Moderate (Moderate Impact)', green: 'Minor (Low/No Impact)' };
-                document.getElementById('activeFilterLabel').textContent = labels[weatherImpactParam] || weatherImpactParam.toUpperCase();
-                document.getElementById('activeFilterBanner').classList.remove('d-none');
-            }
+        // Show active filter banner
+        const labels = {
+            red: 'Extreme (High Impact)',
+            orange: 'Severe (Severe Impact)',
+            yellow: 'Moderate (Moderate Impact)',
+            green: 'Minor (Low/No Impact)'
+        };
+        document.getElementById('activeFilterLabel').textContent =
+            labels[weatherImpactParam] || weatherImpactParam.toUpperCase();
+        document.getElementById('activeFilterBanner').classList.remove('d-none');
+    }
 
-            // Trigger filtering
-            filterOffices();
-        }
+    // Trigger filtering
+    filterOffices();
+}
 
-        // Initialize filters then load offices
-        AlertFilters.init().then(async () => {
-            await loadOffices();
-            // Apply URL parameters after offices are loaded
-            applyURLParameters();
-        });
+// Initialize filters then load offices
+AlertFilters.init().then(async () => {
+    await loadOffices();
+    // Apply URL parameters after offices are loaded
+    applyURLParameters();
+});


### PR DESCRIPTION
## Summary
- Runs Prettier on all 7 `page-*.js` files to normalize 8-space → 4-space indentation
- No mixed tabs/spaces; consistent with `utils.js`, `api.js`, `alert-filters.js`
- Formatting only — no logic changes

Closes #185