### PR TITLE
feat: add ESLint and Prettier checks to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,25 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Check formatting
+        run: npm run format:check
+
   test:
     runs-on: ubuntu-latest
     defaults:

--- a/backend/src/scripts/add-new-offices.js
+++ b/backend/src/scripts/add-new-offices.js
@@ -297,7 +297,7 @@ async function main() {
     const region = STATE_REGIONS[stateCode];
     const progress = `[${i + 1}/${NEW_SITES.length}]`;
     
-    console.log(`${progress} ${office.site_code} - ${office.name} (${site.city}, ${stateCode})`);
+    console.log(`${progress} ${office.site_code} - ${office.name} (${office.city}, ${stateCode})`);
     
     // Step 1: Geocode
     let geo = null;
@@ -326,7 +326,7 @@ async function main() {
       
       if (geo) {
         geo.source = 'nominatim_city_fallback';
-        warnings.push(`${office.site_code} (${site.city}, ${stateCode}): Used city-center coordinates - needs manual verification`);
+        warnings.push(`${office.site_code} (${office.city}, ${stateCode}): Used city-center coordinates - needs manual verification`);
       }
     }
     

--- a/backend/src/scripts/validate-ugc-codes.js
+++ b/backend/src/scripts/validate-ugc-codes.js
@@ -331,7 +331,7 @@ async function main() {
     console.log('  (This is normal for offices located across state lines)\n');
     
     for (const office of crossStateSites) {
-      console.log(`  • ${office.site_code} "${office.name}" (${site.listed_state})`);
+      console.log(`  • ${office.site_code} "${office.name}" (${office.listed_state})`);
       console.log(`    UGC: ${office.ugc_codes.join(', ')} → ${office.county}\n`);
     }
   }


### PR DESCRIPTION
## Summary
- Adds `lint` job to existing CI workflow: runs `npm run lint` and `npm run format:check`
- Triggers on push to main and all pull requests
- Fixes 3 pre-existing `no-undef` lint errors in maintenance scripts (`site` → `office` typos)
- Lint and test jobs run in parallel for faster CI

Closes #187