### PR TITLE
test: Expand unit test coverage for critical backend modules

### DIFF
--- a/backend/tests/unit/api-client.test.js
+++ b/backend/tests/unit/api-client.test.js
@@ -1,0 +1,190 @@
+/**
+ * Unit tests for the API client
+ * Covers: isRetryable, requestWithRetry, circuit breaker state transitions
+ */
+
+jest.mock('axios');
+jest.mock('../../src/config/config', () => ({
+    noaa: {
+        baseUrl: 'https://api.weather.gov',
+        userAgent: 'TestApp/1.0 (test@example.com)'
+    }
+}));
+
+describe('isRetryable', () => {
+    const { _internal } = require('../../src/ingestion/utils/api-client');
+    const { isRetryable } = _internal;
+
+    test('should return true for retryable HTTP status codes', () => {
+        expect(isRetryable({ response: { status: 408 } })).toBe(true);
+        expect(isRetryable({ response: { status: 429 } })).toBe(true);
+        expect(isRetryable({ response: { status: 500 } })).toBe(true);
+        expect(isRetryable({ response: { status: 502 } })).toBe(true);
+        expect(isRetryable({ response: { status: 503 } })).toBe(true);
+        expect(isRetryable({ response: { status: 504 } })).toBe(true);
+    });
+
+    test('should return false for non-retryable HTTP status codes', () => {
+        expect(isRetryable({ response: { status: 400 } })).toBe(false);
+        expect(isRetryable({ response: { status: 401 } })).toBe(false);
+        expect(isRetryable({ response: { status: 403 } })).toBe(false);
+        expect(isRetryable({ response: { status: 404 } })).toBe(false);
+        expect(isRetryable({ response: { status: 422 } })).toBe(false);
+    });
+
+    test('should return true for retryable network error codes', () => {
+        expect(isRetryable({ code: 'ECONNRESET' })).toBe(true);
+        expect(isRetryable({ code: 'ETIMEDOUT' })).toBe(true);
+        expect(isRetryable({ code: 'ECONNREFUSED' })).toBe(true);
+        expect(isRetryable({ code: 'ENOTFOUND' })).toBe(true);
+    });
+
+    test('should return true when error message contains retryable code', () => {
+        expect(isRetryable({ message: 'connect ECONNRESET 1.2.3.4' })).toBe(true);
+        expect(isRetryable({ message: 'request ETIMEDOUT' })).toBe(true);
+    });
+
+    test('should return false for non-retryable errors', () => {
+        expect(isRetryable({ code: 'ERR_BAD_REQUEST' })).toBe(false);
+        expect(isRetryable(new Error('validation failed'))).toBe(false);
+    });
+});
+
+describe('requestWithRetry', () => {
+    let requestWithRetry;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.resetModules();
+        const apiClient = require('../../src/ingestion/utils/api-client');
+        requestWithRetry = apiClient._internal.requestWithRetry;
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test('should return result on immediate success', async () => {
+        const fn = jest.fn().mockResolvedValue({ data: 'ok' });
+        const result = await requestWithRetry(fn, 'test');
+        expect(result).toEqual({ data: 'ok' });
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    test('should throw non-retryable errors immediately without retrying', async () => {
+        const error = { response: { status: 404 }, message: 'Not found' };
+        const fn = jest.fn().mockRejectedValue(error);
+
+        await expect(requestWithRetry(fn, 'test')).rejects.toEqual(error);
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    test('should retry on retryable errors then succeed', async () => {
+        const serverError = { response: { status: 500 }, message: 'Internal server error' };
+        const fn = jest.fn()
+            .mockRejectedValueOnce(serverError)
+            .mockResolvedValue('recovered');
+
+        const promise = requestWithRetry(fn, 'test');
+        await jest.runAllTimersAsync();
+        const result = await promise;
+
+        expect(result).toBe('recovered');
+        expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    test('should throw after exhausting all retries', async () => {
+        const serverError = { response: { status: 500 }, message: 'Server error' };
+        const fn = jest.fn().mockRejectedValue(serverError);
+
+        const promise = requestWithRetry(fn, 'test');
+        // Prevent unhandled rejection warning
+        promise.catch(() => {});
+
+        await jest.runAllTimersAsync();
+
+        await expect(promise).rejects.toEqual(serverError);
+        expect(fn).toHaveBeenCalledTimes(3);
+    });
+});
+
+describe('Circuit breaker state transitions', () => {
+    let requestWithRetry, getCircuitBreakerState;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.resetModules();
+        const apiClient = require('../../src/ingestion/utils/api-client');
+        requestWithRetry = apiClient._internal.requestWithRetry;
+        getCircuitBreakerState = apiClient.getCircuitBreakerState;
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test('should start in CLOSED state', () => {
+        const state = getCircuitBreakerState();
+        expect(state.state).toBe('CLOSED');
+        expect(state.failureCount).toBe(0);
+        expect(state.lastFailureTime).toBeNull();
+    });
+
+    test('should return state snapshot with recoveryTimeMs', () => {
+        const state = getCircuitBreakerState();
+        expect(state.recoveryTimeMs).toBe(60000);
+    });
+
+    test('should transition to OPEN after threshold consecutive failures', async () => {
+        const serverError = { response: { status: 500 }, message: 'Server error' };
+        const fn = jest.fn().mockRejectedValue(serverError);
+
+        for (let i = 0; i < 3; i++) {
+            const promise = requestWithRetry(fn, 'test');
+            promise.catch(() => {});
+            await jest.runAllTimersAsync();
+            try {
+                await promise;
+            } catch (_) {
+                // expected
+            }
+        }
+
+        const state = getCircuitBreakerState();
+        expect(state.state).toBe('OPEN');
+        expect(state.failureCount).toBe(3);
+    });
+
+    test('should reject immediately when circuit is OPEN', async () => {
+        const serverError = { response: { status: 500 }, message: 'Server error' };
+        const failFn = jest.fn().mockRejectedValue(serverError);
+
+        // Open the circuit with 3 consecutive failures
+        for (let i = 0; i < 3; i++) {
+            const promise = requestWithRetry(failFn, 'test');
+            promise.catch(() => {});
+            await jest.runAllTimersAsync();
+            try {
+                await promise;
+            } catch (_) {
+                // expected
+            }
+        }
+
+        expect(getCircuitBreakerState().state).toBe('OPEN');
+
+        // Next call should be rejected immediately with circuit breaker error
+        const freshFn = jest.fn().mockResolvedValue('ok');
+        await expect(requestWithRetry(freshFn, 'test')).rejects.toThrow(/CIRCUIT BREAKER/);
+        expect(freshFn).not.toHaveBeenCalled();
+    });
+
+    test('should reset failure count on success in CLOSED state', async () => {
+        const fn = jest.fn().mockResolvedValue('ok');
+        await requestWithRetry(fn, 'test');
+
+        const state = getCircuitBreakerState();
+        expect(state.state).toBe('CLOSED');
+        expect(state.failureCount).toBe(0);
+    });
+});

--- a/backend/tests/unit/cache.test.js
+++ b/backend/tests/unit/cache.test.js
@@ -1,0 +1,129 @@
+/**
+ * Unit tests for the in-memory cache service
+ */
+
+const cache = require('../../src/utils/cache');
+
+afterEach(() => {
+    cache.invalidateAll();
+});
+
+describe('Cache get/set/del', () => {
+    test('should return undefined for missing key', () => {
+        expect(cache.get('nonexistent')).toBeUndefined();
+    });
+
+    test('should store and retrieve a value', () => {
+        cache.set('testKey', { data: 'hello' });
+        expect(cache.get('testKey')).toEqual({ data: 'hello' });
+    });
+
+    test('should store string values', () => {
+        cache.set('str', 'simple string');
+        expect(cache.get('str')).toBe('simple string');
+    });
+
+    test('should store array values', () => {
+        cache.set('arr', [1, 2, 3]);
+        expect(cache.get('arr')).toEqual([1, 2, 3]);
+    });
+
+    test('should delete a key and return count', () => {
+        cache.set('toDelete', 'value');
+        const count = cache.del('toDelete');
+        expect(count).toBe(1);
+        expect(cache.get('toDelete')).toBeUndefined();
+    });
+
+    test('should return 0 when deleting nonexistent key', () => {
+        const count = cache.del('nonexistent');
+        expect(count).toBe(0);
+    });
+
+    test('should overwrite existing key', () => {
+        cache.set('key', 'first');
+        cache.set('key', 'second');
+        expect(cache.get('key')).toBe('second');
+    });
+});
+
+describe('Cache invalidation', () => {
+    test('invalidateAll should clear all keys', () => {
+        cache.set('a', 1);
+        cache.set('b', 2);
+        cache.set('c', 3);
+        cache.invalidateAll();
+        expect(cache.get('a')).toBeUndefined();
+        expect(cache.get('b')).toBeUndefined();
+        expect(cache.get('c')).toBeUndefined();
+    });
+
+    test('invalidateDynamic should clear advisory and status keys', () => {
+        cache.set(cache.CACHE_KEYS.ACTIVE_ADVISORIES, [{ id: 1 }]);
+        cache.set(cache.CACHE_KEYS.STATUS_OVERVIEW, { total: 5 });
+        cache.set(cache.CACHE_KEYS.ALL_SITES, [{ id: 1 }]);
+        cache.set(cache.CACHE_KEYS.STATES_LIST, ['AK', 'AL']);
+
+        cache.invalidateDynamic();
+
+        // Dynamic keys should be cleared
+        expect(cache.get(cache.CACHE_KEYS.ACTIVE_ADVISORIES)).toBeUndefined();
+        expect(cache.get(cache.CACHE_KEYS.STATUS_OVERVIEW)).toBeUndefined();
+
+        // Static keys should be preserved
+        expect(cache.get(cache.CACHE_KEYS.ALL_SITES)).toEqual([{ id: 1 }]);
+        expect(cache.get(cache.CACHE_KEYS.STATES_LIST)).toEqual(['AK', 'AL']);
+    });
+
+    test('invalidateDynamic should clear filtered advisory keys', () => {
+        cache.set('advisories:filtered:CRITICAL', [{ id: 1 }]);
+        cache.set('advisories:filtered:HIGH', [{ id: 2 }]);
+        cache.set(cache.CACHE_KEYS.ALL_SITES, [{ id: 1 }]);
+
+        cache.invalidateDynamic();
+
+        expect(cache.get('advisories:filtered:CRITICAL')).toBeUndefined();
+        expect(cache.get('advisories:filtered:HIGH')).toBeUndefined();
+        expect(cache.get(cache.CACHE_KEYS.ALL_SITES)).toEqual([{ id: 1 }]);
+    });
+});
+
+describe('Cache stats', () => {
+    test('should return stats with zero values initially', () => {
+        const stats = cache.getStats();
+        expect(stats).toHaveProperty('keys');
+        expect(stats).toHaveProperty('hits');
+        expect(stats).toHaveProperty('misses');
+        expect(stats).toHaveProperty('hitRate');
+    });
+
+    test('should track key count', () => {
+        cache.set('a', 1);
+        cache.set('b', 2);
+        const stats = cache.getStats();
+        expect(stats.keys).toBe(2);
+    });
+
+    test('should calculate hit rate', () => {
+        cache.set('key', 'value');
+        cache.get('key');       // hit
+        cache.get('key');       // hit
+        cache.get('missing');   // miss
+        const stats = cache.getStats();
+        expect(parseFloat(stats.hitRate)).toBeGreaterThan(0);
+    });
+});
+
+describe('Cache constants', () => {
+    test('CACHE_KEYS should have expected keys', () => {
+        expect(cache.CACHE_KEYS.STATUS_OVERVIEW).toBe('status:overview');
+        expect(cache.CACHE_KEYS.ALL_SITES).toBe('sites:all');
+        expect(cache.CACHE_KEYS.ACTIVE_ADVISORIES).toBe('advisories:active');
+    });
+
+    test('TTL should have expected values', () => {
+        expect(cache.TTL.SHORT).toBe(900);
+        expect(cache.TTL.LONG).toBe(3600);
+        expect(cache.TTL.VERY_LONG).toBe(86400);
+    });
+});

--- a/backend/tests/unit/cleanup.test.js
+++ b/backend/tests/unit/cleanup.test.js
@@ -1,0 +1,210 @@
+/**
+ * Unit tests for the advisory cleanup module
+ * Covers: batchDelete batching, runCleanup mode routing, error handling
+ */
+
+jest.mock('../../src/config/database', () => ({
+    initDatabase: jest.fn().mockResolvedValue(true),
+    getDatabase: jest.fn(),
+    closeDatabase: jest.fn().mockResolvedValue(true)
+}));
+
+jest.mock('../../src/utils/alerting', () => ({
+    alertCleanupFailure: jest.fn().mockResolvedValue(true)
+}));
+
+const { getDatabase, initDatabase, closeDatabase } = require('../../src/config/database');
+const { alertCleanupFailure } = require('../../src/utils/alerting');
+const { batchDelete, runCleanup, BATCH_SIZE } = require('../../src/utils/cleanup-advisories');
+
+function createMockDb() {
+    return {
+        query: jest.fn().mockResolvedValue([{ affectedRows: 0 }]),
+        getConnection: jest.fn()
+    };
+}
+
+describe('BATCH_SIZE constant', () => {
+    test('should be 1000', () => {
+        expect(BATCH_SIZE).toBe(1000);
+    });
+});
+
+describe('batchDelete', () => {
+    let mockDb;
+
+    beforeEach(() => {
+        mockDb = createMockDb();
+        getDatabase.mockReturnValue(mockDb);
+    });
+
+    test('should return 0 for empty array', async () => {
+        const result = await batchDelete([]);
+        expect(result).toBe(0);
+        expect(mockDb.query).not.toHaveBeenCalled();
+    });
+
+    test('should delete all IDs in a single batch when under BATCH_SIZE', async () => {
+        const ids = [1, 2, 3, 4, 5];
+        mockDb.query.mockResolvedValue([{ affectedRows: 5 }]);
+
+        const result = await batchDelete(ids);
+        expect(result).toBe(5);
+        expect(mockDb.query).toHaveBeenCalledTimes(1);
+        expect(mockDb.query).toHaveBeenCalledWith(
+            'DELETE FROM advisories WHERE id IN (?)',
+            [ids]
+        );
+    });
+
+    test('should split into multiple batches when exceeding BATCH_SIZE', async () => {
+        const ids = Array.from({ length: 2500 }, (_, i) => i + 1);
+        mockDb.query
+            .mockResolvedValueOnce([{ affectedRows: 1000 }])
+            .mockResolvedValueOnce([{ affectedRows: 1000 }])
+            .mockResolvedValueOnce([{ affectedRows: 500 }]);
+
+        const result = await batchDelete(ids);
+        expect(result).toBe(2500);
+        expect(mockDb.query).toHaveBeenCalledTimes(3);
+    });
+
+    test('should use custom table name', async () => {
+        mockDb.query.mockResolvedValue([{ affectedRows: 1 }]);
+        await batchDelete([1], 'custom_table');
+        expect(mockDb.query).toHaveBeenCalledWith(
+            'DELETE FROM custom_table WHERE id IN (?)',
+            [[1]]
+        );
+    });
+});
+
+describe('runCleanup', () => {
+    let mockDb;
+
+    beforeEach(() => {
+        mockDb = createMockDb();
+        getDatabase.mockReturnValue(mockDb);
+        initDatabase.mockResolvedValue(true);
+        closeDatabase.mockResolvedValue(true);
+        alertCleanupFailure.mockClear();
+        jest.spyOn(process, 'exit').mockImplementation(() => {});
+
+        // Schema check returns all required columns
+        mockDb.query.mockImplementation((sql) => {
+            if (sql.includes('INFORMATION_SCHEMA.COLUMNS')) {
+                return [[
+                    { COLUMN_NAME: 'external_id' },
+                    { COLUMN_NAME: 'vtec_code' },
+                    { COLUMN_NAME: 'vtec_event_id' },
+                    { COLUMN_NAME: 'vtec_action' }
+                ]];
+            }
+            // GROUP BY queries (duplicate searches) — return no duplicates
+            if (sql.includes('GROUP BY')) {
+                return [[]];
+            }
+            // SELECT id queries (expired advisory search) — return none
+            if (sql.includes('SELECT id FROM')) {
+                return [[]];
+            }
+            // SELECT with raw_payload (populateExternalIds) — return none
+            if (sql.includes('raw_payload')) {
+                return [[]];
+            }
+            // UPDATE/DELETE results
+            return [{ affectedRows: 0 }];
+        });
+    });
+
+    afterEach(() => {
+        process.exit.mockRestore();
+    });
+
+    test('should run full cleanup mode', async () => {
+        const results = await runCleanup('full', { silent: true, exitOnComplete: false });
+
+        expect(results.mode).toBe('full');
+        expect(results.success).toBe(true);
+        expect(results.totalRemoved).toBe(0);
+        expect(initDatabase).toHaveBeenCalled();
+    });
+
+    test('should run expired mode', async () => {
+        const results = await runCleanup('expired', { silent: true, exitOnComplete: false });
+
+        expect(results.mode).toBe('expired');
+        expect(results.success).toBe(true);
+    });
+
+    test('should run vtec mode', async () => {
+        const results = await runCleanup('vtec', { silent: true, exitOnComplete: false });
+
+        expect(results.mode).toBe('vtec');
+        expect(results.success).toBe(true);
+    });
+
+    test('should run event_id mode', async () => {
+        const results = await runCleanup('event_id', { silent: true, exitOnComplete: false });
+
+        expect(results.mode).toBe('event_id');
+        expect(results.success).toBe(true);
+    });
+
+    test('should run duplicates mode', async () => {
+        const results = await runCleanup('duplicates', { silent: true, exitOnComplete: false });
+
+        expect(results.mode).toBe('duplicates');
+        expect(results.success).toBe(true);
+    });
+
+    test('should fail with unknown mode', async () => {
+        const results = await runCleanup('invalid_mode', { silent: true, exitOnComplete: false });
+
+        expect(results.success).toBe(false);
+        expect(results.error).toContain('Unknown cleanup mode');
+        expect(alertCleanupFailure).toHaveBeenCalled();
+    });
+
+    test('should handle database initialization failure', async () => {
+        initDatabase.mockRejectedValue(new Error('Connection failed'));
+
+        const results = await runCleanup('full', { silent: true, exitOnComplete: false });
+
+        expect(results.success).toBe(false);
+        expect(results.error).toBe('Connection failed');
+    });
+
+    test('should call process.exit with 0 on success when exitOnComplete is true', async () => {
+        await runCleanup('expired', { silent: true, exitOnComplete: true });
+
+        expect(closeDatabase).toHaveBeenCalled();
+        expect(process.exit).toHaveBeenCalledWith(0);
+    });
+
+    test('should call process.exit with 1 on failure when exitOnComplete is true', async () => {
+        initDatabase.mockRejectedValue(new Error('fail'));
+        await runCleanup('full', { silent: true, exitOnComplete: true });
+
+        expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
+    test('should calculate totalRemoved as sum of all removal counts', async () => {
+        const results = await runCleanup('full', { silent: true, exitOnComplete: false });
+
+        const expected =
+            results.externalIdDuplicates +
+            results.vtecEventIdDuplicates +
+            results.vtecCodeDuplicates +
+            results.typeDuplicates +
+            results.expiredRemoved;
+        expect(results.totalRemoved).toBe(expected);
+    });
+
+    test('should include startTime in results', async () => {
+        const results = await runCleanup('full', { silent: true, exitOnComplete: false });
+
+        expect(results.startTime).toBeDefined();
+        expect(new Date(results.startTime).getTime()).not.toBeNaN();
+    });
+});

--- a/backend/tests/unit/normalizer.test.js
+++ b/backend/tests/unit/normalizer.test.js
@@ -1,0 +1,331 @@
+/**
+ * Unit tests for the normalizer utility functions
+ * Covers: getSeverityFromAlertType, normalizeSeverity, extractVTECEventID,
+ * extractVTECAction, isPointInAlertArea, calculateWeatherImpact,
+ * calculateHighestWeatherImpact, formatStatusReason, normalizeNOAAAlert datetime handling
+ *
+ * extractVTEC and normalizeNOAAAlert core fields are covered in vtec-extraction.test.js
+ */
+
+const {
+    normalizeSeverity,
+    normalizeNOAAAlert,
+    getSeverityFromAlertType,
+    extractVTECEventID,
+    extractVTECAction,
+    isPointInAlertArea,
+    calculateWeatherImpact,
+    calculateHighestWeatherImpact,
+    formatStatusReason,
+    calculateOperationalStatus
+} = require('../../src/ingestion/utils/normalizer');
+
+describe('getSeverityFromAlertType', () => {
+    test('should return Extreme for CRITICAL alert types', () => {
+        expect(getSeverityFromAlertType('Tornado Warning')).toBe('Extreme');
+        expect(getSeverityFromAlertType('Hurricane Warning')).toBe('Extreme');
+        expect(getSeverityFromAlertType('Tsunami Warning')).toBe('Extreme');
+        expect(getSeverityFromAlertType('Flash Flood Warning')).toBe('Extreme');
+    });
+
+    test('should return Severe for HIGH alert types', () => {
+        expect(getSeverityFromAlertType('Winter Storm Warning')).toBe('Severe');
+        expect(getSeverityFromAlertType('Flood Warning')).toBe('Severe');
+        expect(getSeverityFromAlertType('High Wind Warning')).toBe('Severe');
+        expect(getSeverityFromAlertType('Tornado Watch')).toBe('Severe');
+    });
+
+    test('should return Moderate for MODERATE alert types', () => {
+        expect(getSeverityFromAlertType('Winter Weather Advisory')).toBe('Moderate');
+        expect(getSeverityFromAlertType('Wind Advisory')).toBe('Moderate');
+        expect(getSeverityFromAlertType('Heat Advisory')).toBe('Moderate');
+        expect(getSeverityFromAlertType('Dense Fog Advisory')).toBe('Moderate');
+    });
+
+    test('should return Minor for LOW alert types', () => {
+        expect(getSeverityFromAlertType('Small Craft Advisory')).toBe('Minor');
+        expect(getSeverityFromAlertType('Rip Current Statement')).toBe('Minor');
+        expect(getSeverityFromAlertType('Cold Weather Advisory')).toBe('Minor');
+    });
+
+    test('should return Minor for INFO alert types', () => {
+        expect(getSeverityFromAlertType('Special Weather Statement')).toBe('Minor');
+        expect(getSeverityFromAlertType('Hazardous Weather Outlook')).toBe('Minor');
+    });
+
+    test('should return Minor for null/undefined/empty', () => {
+        expect(getSeverityFromAlertType(null)).toBe('Minor');
+        expect(getSeverityFromAlertType(undefined)).toBe('Minor');
+        expect(getSeverityFromAlertType('')).toBe('Minor');
+    });
+
+    test('should return Minor for unknown alert types', () => {
+        expect(getSeverityFromAlertType('Made Up Warning')).toBe('Minor');
+    });
+});
+
+describe('normalizeSeverity', () => {
+    test('should normalize valid severity strings', () => {
+        expect(normalizeSeverity('Extreme')).toBe('Extreme');
+        expect(normalizeSeverity('Severe')).toBe('Severe');
+        expect(normalizeSeverity('Moderate')).toBe('Moderate');
+        expect(normalizeSeverity('Minor')).toBe('Minor');
+    });
+
+    test('should be case-insensitive', () => {
+        expect(normalizeSeverity('extreme')).toBe('Extreme');
+        expect(normalizeSeverity('SEVERE')).toBe('Severe');
+        expect(normalizeSeverity('moderate')).toBe('Moderate');
+        expect(normalizeSeverity('MINOR')).toBe('Minor');
+    });
+
+    test('should return Minor for null/undefined/empty', () => {
+        expect(normalizeSeverity(null)).toBe('Minor');
+        expect(normalizeSeverity(undefined)).toBe('Minor');
+        expect(normalizeSeverity('')).toBe('Minor');
+    });
+
+    test('should return Minor for invalid values', () => {
+        expect(normalizeSeverity('Critical')).toBe('Minor');
+        expect(normalizeSeverity('Unknown')).toBe('Minor');
+        expect(normalizeSeverity('nonsense')).toBe('Minor');
+    });
+});
+
+describe('extractVTECEventID', () => {
+    test('should extract event ID from valid VTEC code', () => {
+        const vtec = '/O.CON.PAJK.WS.W.0005.000000T0000Z-260213T0000Z/';
+        expect(extractVTECEventID(vtec)).toBe('PAJK.WS.W.0005');
+    });
+
+    test('should extract event ID for different action codes', () => {
+        expect(extractVTECEventID('/O.NEW.KBOU.WS.W.0012.260301T0000Z-260302T0000Z/')).toBe('KBOU.WS.W.0012');
+        expect(extractVTECEventID('/O.EXT.KMSO.HW.W.0006.260212T1200Z-260213T0300Z/')).toBe('KMSO.HW.W.0006');
+        expect(extractVTECEventID('/O.EXP.KPHI.WW.Y.0009.260211T1200Z-260212T0000Z/')).toBe('KPHI.WW.Y.0009');
+        expect(extractVTECEventID('/O.CAN.KORD.WS.W.0003.260301T0000Z-260302T0000Z/')).toBe('KORD.WS.W.0003');
+    });
+
+    test('should return null for null/undefined/empty input', () => {
+        expect(extractVTECEventID(null)).toBeNull();
+        expect(extractVTECEventID(undefined)).toBeNull();
+        expect(extractVTECEventID('')).toBeNull();
+    });
+
+    test('should return null for malformed VTEC code', () => {
+        expect(extractVTECEventID('not-a-vtec-code')).toBeNull();
+        expect(extractVTECEventID('/invalid/')).toBeNull();
+    });
+});
+
+describe('extractVTECAction', () => {
+    test('should extract action code from valid VTEC', () => {
+        expect(extractVTECAction('/O.CON.PAJK.WS.W.0005.000000T0000Z-260213T0000Z/')).toBe('CON');
+        expect(extractVTECAction('/O.NEW.KBOU.WS.W.0012.260301T0000Z-260302T0000Z/')).toBe('NEW');
+        expect(extractVTECAction('/O.EXT.KMSO.HW.W.0006.260212T1200Z-260213T0300Z/')).toBe('EXT');
+        expect(extractVTECAction('/O.EXP.KPHI.WW.Y.0009.260211T1200Z-260212T0000Z/')).toBe('EXP');
+        expect(extractVTECAction('/O.CAN.KORD.WS.W.0003.260301T0000Z-260302T0000Z/')).toBe('CAN');
+        expect(extractVTECAction('/O.UPG.KLOT.WS.W.0001.260301T0000Z-260302T0000Z/')).toBe('UPG');
+    });
+
+    test('should return null for null/undefined/empty input', () => {
+        expect(extractVTECAction(null)).toBeNull();
+        expect(extractVTECAction(undefined)).toBeNull();
+        expect(extractVTECAction('')).toBeNull();
+    });
+
+    test('should return null for malformed VTEC code', () => {
+        expect(extractVTECAction('not-a-vtec-code')).toBeNull();
+    });
+});
+
+describe('isPointInAlertArea', () => {
+    // Square polygon: corners at (0,0), (10,0), (10,10), (0,10) in [lon, lat]
+    const squarePolygon = {
+        type: 'Polygon',
+        coordinates: [
+            [
+                [0, 0],
+                [10, 0],
+                [10, 10],
+                [0, 10],
+                [0, 0]
+            ]
+        ]
+    };
+
+    test('should return true when point is inside polygon', () => {
+        expect(isPointInAlertArea(5, 5, squarePolygon)).toBe(true);
+    });
+
+    test('should return false when point is outside polygon', () => {
+        expect(isPointInAlertArea(15, 15, squarePolygon)).toBe(false);
+        expect(isPointInAlertArea(-1, -1, squarePolygon)).toBe(false);
+    });
+
+    test('should return true when geometry is null/undefined', () => {
+        expect(isPointInAlertArea(5, 5, null)).toBe(true);
+        expect(isPointInAlertArea(5, 5, undefined)).toBe(true);
+    });
+
+    test('should return true when geometry has no coordinates', () => {
+        expect(isPointInAlertArea(5, 5, { type: 'Polygon' })).toBe(true);
+    });
+
+    test('should handle MultiPolygon geometry', () => {
+        const multiPolygon = {
+            type: 'MultiPolygon',
+            coordinates: [
+                [[[0, 0], [5, 0], [5, 5], [0, 5], [0, 0]]],
+                [[[20, 20], [25, 20], [25, 25], [20, 25], [20, 20]]]
+            ]
+        };
+
+        expect(isPointInAlertArea(2, 2, multiPolygon)).toBe(true);
+        expect(isPointInAlertArea(22, 22, multiPolygon)).toBe(true);
+        expect(isPointInAlertArea(10, 10, multiPolygon)).toBe(false);
+    });
+
+    test('should return true for unknown geometry type', () => {
+        expect(isPointInAlertArea(5, 5, { type: 'Point', coordinates: [5, 5] })).toBe(true);
+    });
+});
+
+describe('calculateWeatherImpact', () => {
+    test('should map severity to correct impact color', () => {
+        expect(calculateWeatherImpact('Extreme')).toBe('red');
+        expect(calculateWeatherImpact('Severe')).toBe('orange');
+        expect(calculateWeatherImpact('Moderate')).toBe('yellow');
+        expect(calculateWeatherImpact('Minor')).toBe('green');
+        expect(calculateWeatherImpact('Unknown')).toBe('green');
+    });
+
+    test('should default to green for unrecognized severity', () => {
+        expect(calculateWeatherImpact('nonsense')).toBe('green');
+        expect(calculateWeatherImpact(undefined)).toBe('green');
+    });
+
+    test('calculateOperationalStatus should be an alias', () => {
+        expect(calculateOperationalStatus).toBe(calculateWeatherImpact);
+    });
+});
+
+describe('calculateHighestWeatherImpact', () => {
+    test('should return highest impact from multiple advisories', () => {
+        const advisories = [
+            { severity: 'Minor' },
+            { severity: 'Extreme' },
+            { severity: 'Moderate' }
+        ];
+        expect(calculateHighestWeatherImpact(advisories)).toBe('red');
+    });
+
+    test('should return green for empty/null advisories', () => {
+        expect(calculateHighestWeatherImpact([])).toBe('green');
+        expect(calculateHighestWeatherImpact(null)).toBe('green');
+        expect(calculateHighestWeatherImpact(undefined)).toBe('green');
+    });
+
+    test('should return correct impact for single advisory', () => {
+        expect(calculateHighestWeatherImpact([{ severity: 'Severe' }])).toBe('orange');
+    });
+
+    test('should handle all moderate advisories', () => {
+        const advisories = [{ severity: 'Moderate' }, { severity: 'Moderate' }];
+        expect(calculateHighestWeatherImpact(advisories)).toBe('yellow');
+    });
+});
+
+describe('formatStatusReason', () => {
+    test('should return message for no advisories', () => {
+        expect(formatStatusReason([])).toBe('No active advisories');
+        expect(formatStatusReason(null)).toBe('No active advisories');
+        expect(formatStatusReason(undefined)).toBe('No active advisories');
+    });
+
+    test('should return advisory type for single advisory', () => {
+        const advisories = [{ advisory_type: 'Tornado Warning', severity: 'Extreme' }];
+        expect(formatStatusReason(advisories)).toBe('Tornado Warning');
+    });
+
+    test('should format multiple advisories with count', () => {
+        const advisories = [
+            { advisory_type: 'Tornado Warning', severity: 'Extreme' },
+            { advisory_type: 'Flood Warning', severity: 'Severe' },
+            { advisory_type: 'Wind Advisory', severity: 'Moderate' }
+        ];
+        expect(formatStatusReason(advisories)).toBe('Tornado Warning + 2 more');
+    });
+
+    test('should pick highest severity advisory for the label', () => {
+        const advisories = [
+            { advisory_type: 'Wind Advisory', severity: 'Moderate' },
+            { advisory_type: 'Tornado Warning', severity: 'Extreme' }
+        ];
+        expect(formatStatusReason(advisories)).toBe('Tornado Warning + 1 more');
+    });
+});
+
+describe('normalizeNOAAAlert datetime handling', () => {
+    test('should convert ISO timestamps to MySQL DATETIME format', () => {
+        const alert = {
+            properties: {
+                event: 'Wind Advisory',
+                status: 'Actual',
+                onset: '2026-03-01T12:00:00Z',
+                ends: '2026-03-02T00:00:00Z',
+                sent: '2026-03-01T10:00:00Z',
+                parameters: {}
+            }
+        };
+
+        const normalized = normalizeNOAAAlert(alert);
+        expect(normalized.start_time).toBe('2026-03-01 12:00:00');
+        expect(normalized.end_time).toBe('2026-03-02 00:00:00');
+        expect(normalized.issued_time).toBe('2026-03-01 10:00:00');
+    });
+
+    test('should handle null end time', () => {
+        const alert = {
+            properties: {
+                event: 'Wind Advisory',
+                status: 'Actual',
+                onset: '2026-03-01T12:00:00Z',
+                sent: '2026-03-01T10:00:00Z',
+                parameters: {}
+            }
+        };
+
+        const normalized = normalizeNOAAAlert(alert);
+        expect(normalized.end_time).toBeNull();
+    });
+
+    test('should map non-Actual status to expired', () => {
+        const alert = {
+            properties: {
+                event: 'Wind Advisory',
+                status: 'Test',
+                onset: '2026-03-01T12:00:00Z',
+                sent: '2026-03-01T10:00:00Z',
+                parameters: {}
+            }
+        };
+
+        const normalized = normalizeNOAAAlert(alert);
+        expect(normalized.status).toBe('expired');
+    });
+
+    test('should include raw_payload as the original alert object', () => {
+        const alert = {
+            properties: {
+                event: 'Wind Advisory',
+                status: 'Actual',
+                onset: '2026-03-01T12:00:00Z',
+                sent: '2026-03-01T10:00:00Z',
+                parameters: {}
+            }
+        };
+
+        const normalized = normalizeNOAAAlert(alert);
+        expect(normalized.raw_payload).toBe(alert);
+    });
+});


### PR DESCRIPTION
## Summary
- Adds 4 new test files covering cache, normalizer, API client, and cleanup modules
- Increases total test count from 46 to 129 (83 new tests)
- All tests pass in under 1 second

### Test files added:
- **cache.test.js** — get/set/del, invalidation (all vs dynamic), stats, constants
- **normalizer.test.js** — severity mapping, VTEC event ID/action extraction, point-in-polygon (Polygon/MultiPolygon), weather impact calculations, status reason formatting, datetime handling
- **api-client.test.js** — isRetryable (HTTP status codes + network errors), requestWithRetry (success, non-retryable, retry-then-succeed, exhausted retries), circuit breaker state transitions (CLOSED→OPEN, immediate rejection when OPEN)
- **cleanup.test.js** — batchDelete batching logic, BATCH_SIZE constant, runCleanup mode routing (full/expired/vtec/event_id/duplicates), error handling, process.exit behavior

Closes #188

## Test plan
- [x] All 129 tests pass (`npm test`)
- [x] No flaky timer-based tests (uses `jest.runAllTimersAsync()` for async retry/circuit breaker tests)
- [x] Database-dependent cleanup tests fully mocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)