### PR TITLE
fix: resolve P2 issues — fetch timeout, filter warnings, snapshot race, Prometheus metrics

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,7 +19,8 @@
         "helmet": "^8.1.0",
         "mysql2": "^3.6.5",
         "node-cache": "^5.1.2",
-        "node-cron": "^3.0.3"
+        "node-cron": "^3.0.3",
+        "prom-client": "^15.1.3"
       },
       "devDependencies": {
         "eslint": "^8.57.0",
@@ -1303,6 +1304,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -2049,6 +2059,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.4",
@@ -6224,6 +6240,19 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -7126,6 +7155,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/test-exclude": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -46,7 +46,8 @@
     "helmet": "^8.1.0",
     "mysql2": "^3.6.5",
     "node-cache": "^5.1.2",
-    "node-cron": "^3.0.3"
+    "node-cron": "^3.0.3",
+    "prom-client": "^15.1.3"
   },
   "devDependencies": {
     "eslint": "^8.57.0",

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -13,6 +13,7 @@ const config = require('./config/config');
 const { getDatabase } = require('./config/database');
 const { apiLimiter, writeLimiter, authLimiter } = require('./middleware/rateLimiter');
 const { requireApiKey } = require('./middleware/apiKey');
+const { metricsMiddleware, mountMetricsEndpoint } = require('./middleware/metrics');
 
 // Import routes
 const sitesRouter = require('./routes/offices');
@@ -107,6 +108,9 @@ app.use(compression()); // Gzip API responses and static files (~85% size reduct
 app.use(express.json({ limit: '100kb' }));
 app.use(express.urlencoded({ extended: true, limit: '100kb' }));
 
+// Prometheus metrics — request counting and duration histogram
+app.use(metricsMiddleware);
+
 // Rate limiting - apply to all /api routes
 app.use('/api', apiLimiter);
 
@@ -170,6 +174,9 @@ if (config.env === 'development' || jsonLogging) {
 
 // Liveness probe — always returns 200 with no I/O, for supervisor keep-alive checks. (closes #104)
 app.get('/ping', (req, res) => res.json({ status: 'ok' }));
+
+// Prometheus metrics endpoint — unauthenticated, for Prometheus scraping
+mountMetricsEndpoint(app);
 
 // Public health check — returns only status for load balancers and supervisors.
 // Detailed diagnostics (memory, circuit breaker, ingestion) are at /api/admin/health behind API key auth.

--- a/backend/src/ingestion/scheduler.js
+++ b/backend/src/ingestion/scheduler.js
@@ -8,6 +8,7 @@ const config = require('../config/config');
 const { ingestNOAAData } = require('./noaa-ingestor');
 const { alertIngestionFailure, alertIngestionRecovery } = require('../utils/alerting');
 const { captureSnapshot } = require('../scripts/capture-historical-snapshot');
+const { ingestionCycleDuration, ingestionAdvisoriesTotal } = require('../middleware/metrics');
 
 let scheduledTask = null;
 let snapshotTask = null;
@@ -96,12 +97,17 @@ function startScheduler() {
             return;
         }
         isIngesting = true;
+        const stopTimer = ingestionCycleDuration.startTimer();
         try {
-            await ingestNOAAData();
+            const result = await ingestNOAAData();
+            if (result && result.advisoriesCreated) {
+                ingestionAdvisoriesTotal.inc(result.advisoriesCreated);
+            }
             await handleIngestionResult(null);
         } catch (error) {
             await handleIngestionResult(error);
         } finally {
+            stopTimer();
             isIngesting = false;
         }
     });
@@ -150,36 +156,31 @@ function startScheduler() {
         }
     });
 
-    // Run initial ingestion immediately
+    // Run initial ingestion immediately, then trigger the initial snapshot
+    // once ingestion completes. Chaining via .finally() guarantees the snapshot
+    // never fires mid-ingestion (closes the race condition from the old
+    // setTimeout(5000) approach).
     console.log('Running initial ingestion...');
     isIngesting = true;
     ingestNOAAData()
         .then(() => handleIngestionResult(null))
         .catch((error) => handleIngestionResult(error))
-        .finally(() => {
+        .finally(async () => {
             isIngesting = false;
-        });
 
-    // Run initial snapshot once ingestion settles (waits for idle rather than
-    // relying on a fixed 5-second delay, which could still race on slow systems)
-    console.log('Scheduling initial historical snapshot after ingestion completes...');
-    setTimeout(async () => {
-        if (isSnapshoting) return;
-        isSnapshoting = true;
-        try {
-            if (isIngesting) {
-                console.log('[Scheduler] Initial snapshot waiting for ingestion to complete...');
-                await waitForIngestionIdle();
+            // Capture initial historical snapshot now that ingestion is done
+            if (isSnapshoting) return;
+            isSnapshoting = true;
+            try {
+                console.log('[Scheduler] Running initial historical snapshot...');
+                const result = await captureSnapshot();
+                console.log(`[Scheduler] Initial snapshot completed: ${result.sites_captured} sites captured`);
+            } catch (error) {
+                console.error('[Scheduler] Initial snapshot failed:', error.message);
+            } finally {
+                isSnapshoting = false;
             }
-            console.log('[Scheduler] Running initial historical snapshot...');
-            const result = await captureSnapshot();
-            console.log(`[Scheduler] Initial snapshot completed: ${result.sites_captured} sites captured`);
-        } catch (error) {
-            console.error('[Scheduler] Initial snapshot failed:', error.message);
-        } finally {
-            isSnapshoting = false;
-        }
-    }, 5000);
+        });
 }
 
 /**

--- a/backend/src/middleware/metrics.js
+++ b/backend/src/middleware/metrics.js
@@ -1,0 +1,133 @@
+/**
+ * Prometheus Metrics Middleware
+ * Exposes application metrics at GET /metrics for Prometheus scraping.
+ */
+
+const client = require('prom-client');
+
+// Collect default Node.js metrics (GC, event loop, heap, etc.)
+client.collectDefaultMetrics();
+
+// ── HTTP request metrics ────────────────────────────────────────────────
+
+const httpRequestsTotal = new client.Counter({
+    name: 'http_requests_total',
+    help: 'Total HTTP requests',
+    labelNames: ['method', 'route', 'status']
+});
+
+const httpRequestDuration = new client.Histogram({
+    name: 'http_request_duration_seconds',
+    help: 'HTTP request duration in seconds',
+    labelNames: ['method', 'route', 'status'],
+    buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
+});
+
+// ── Ingestion metrics ───────────────────────────────────────────────────
+
+const ingestionCycleDuration = new client.Histogram({
+    name: 'ingestion_cycle_duration_seconds',
+    help: 'NOAA ingestion cycle duration in seconds',
+    buckets: [10, 30, 60, 120, 300, 600]
+});
+
+const ingestionAdvisoriesTotal = new client.Counter({
+    name: 'ingestion_advisories_total',
+    help: 'Total advisories ingested'
+});
+
+// ── Cache metrics ───────────────────────────────────────────────────────
+
+const cacheHitsTotal = new client.Counter({
+    name: 'cache_hits_total',
+    help: 'Total cache hits'
+});
+
+const cacheMissesTotal = new client.Counter({
+    name: 'cache_misses_total',
+    help: 'Total cache misses'
+});
+
+// ── Circuit breaker metric ──────────────────────────────────────────────
+
+const circuitBreakerState = new client.Gauge({
+    name: 'circuit_breaker_state',
+    help: 'NOAA circuit breaker state (0=CLOSED, 1=HALF_OPEN, 2=OPEN)'
+});
+
+// ── DB pool metric ──────────────────────────────────────────────────────
+
+const dbPoolActiveConnections = new client.Gauge({
+    name: 'db_pool_active_connections',
+    help: 'Active database pool connections'
+});
+
+/**
+ * Express middleware that records request count and duration.
+ * Normalises route paths to avoid high-cardinality label explosions
+ * (e.g. /api/trends/123 → /api/trends/:id).
+ */
+function metricsMiddleware(req, res, next) {
+    const start = process.hrtime.bigint();
+    res.on('finish', () => {
+        const durationSec = Number(process.hrtime.bigint() - start) / 1e9;
+        const route = normaliseRoute(req.route ? req.route.path : req.path);
+        const labels = { method: req.method, route, status: res.statusCode };
+        httpRequestsTotal.inc(labels);
+        httpRequestDuration.observe(labels, durationSec);
+    });
+    next();
+}
+
+/**
+ * Collapse numeric path segments to :id to keep cardinality manageable.
+ */
+function normaliseRoute(path) {
+    return path.replace(/\/\d+/g, '/:id');
+}
+
+const CIRCUIT_STATE_MAP = { CLOSED: 0, HALF_OPEN: 1, OPEN: 2 };
+
+/**
+ * Mount the /metrics endpoint on an Express app.
+ * Should be called once during app setup.
+ * Updates point-in-time gauges (circuit breaker, DB pool) on each scrape.
+ */
+function mountMetricsEndpoint(app) {
+    app.get('/metrics', async (req, res) => {
+        // Update circuit breaker gauge from current state
+        try {
+            const { getCircuitBreakerState } = require('../ingestion/utils/api-client');
+            const cb = getCircuitBreakerState();
+            circuitBreakerState.set(CIRCUIT_STATE_MAP[cb.state] ?? 0);
+        } catch (_) {
+            /* api-client not loaded yet */
+        }
+
+        // Update DB pool gauge
+        try {
+            const { getDatabase } = require('../config/database');
+            const pool = getDatabase();
+            if (pool.pool) {
+                dbPoolActiveConnections.set(pool.pool._allConnections.length - pool.pool._freeConnections.length);
+            }
+        } catch (_) {
+            /* DB not initialised yet */
+        }
+
+        res.set('Content-Type', client.register.contentType);
+        res.end(await client.register.metrics());
+    });
+}
+
+module.exports = {
+    metricsMiddleware,
+    mountMetricsEndpoint,
+    // Expose counters/gauges so other modules can instrument themselves
+    ingestionCycleDuration,
+    ingestionAdvisoriesTotal,
+    cacheHitsTotal,
+    cacheMissesTotal,
+    circuitBreakerState,
+    dbPoolActiveConnections
+};

--- a/backend/src/utils/cache.js
+++ b/backend/src/utils/cache.js
@@ -4,6 +4,7 @@
  */
 
 const NodeCache = require('node-cache');
+const { cacheHitsTotal, cacheMissesTotal } = require('../middleware/metrics');
 
 const isDevMode = process.env.NODE_ENV !== 'production';
 
@@ -46,9 +47,11 @@ const TTL = {
 function get(key) {
     const value = cache.get(key);
     if (value !== undefined) {
+        cacheHitsTotal.inc();
         if (isDevMode) console.log(`[CACHE] HIT: ${key}`);
         return value;
     }
+    cacheMissesTotal.inc();
     if (isDevMode) console.log(`[CACHE] MISS: ${key}`);
     return undefined;
 }

--- a/frontend/js/aggregation.js
+++ b/frontend/js/aggregation.js
@@ -220,6 +220,9 @@ const OfficeAggregator = {
             return null;
         }
 
+        // Detect whether ALL alerts are hidden (no types selected)
+        const allHidden = allAdvisories.length > 0 && filteredAdvisories.length === 0;
+
         // Check for hidden critical alerts
         const hiddenAdvisories = allAdvisories.filter((a) => !filteredAdvisories.includes(a));
         const criticalHidden = hiddenAdvisories.filter(
@@ -229,7 +232,8 @@ const OfficeAggregator = {
         return {
             hidden_count: hiddenCount,
             critical_hidden: criticalHidden,
-            has_critical: criticalHidden > 0
+            has_critical: criticalHidden > 0,
+            all_hidden: allHidden
         };
     }
 };

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -8,6 +8,27 @@ const API_BASE_URL =
         ? `${window.location.protocol}//${window.location.host}/api`
         : '/api';
 
+const DEFAULT_TIMEOUT_MS = 30000;
+
+/**
+ * Fetch with an AbortController timeout.
+ * Prevents the page from hanging indefinitely if the backend is unresponsive.
+ * @param {string} url - URL to fetch
+ * @param {RequestInit} [options={}] - Fetch options
+ * @param {number} [timeoutMs=30000] - Timeout in milliseconds
+ * @returns {Promise<Response>}
+ */
+async function fetchWithTimeout(url, options = {}, timeoutMs = DEFAULT_TIMEOUT_MS) {
+    const controller = new AbortController();
+    const id = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+        const response = await fetchWithTimeout(url, { ...options, signal: controller.signal });
+        return response;
+    } finally {
+        clearTimeout(id);
+    }
+}
+
 let _versionCache = null;
 
 const API = {
@@ -18,7 +39,7 @@ const API = {
     async getVersion() {
         if (_versionCache) return _versionCache;
         try {
-            const response = await fetch(`${API_BASE_URL}/version`);
+            const response = await fetchWithTimeout(`${API_BASE_URL}/version`);
             _versionCache = await response.json();
             return _versionCache;
         } catch (error) {
@@ -45,7 +66,7 @@ const API = {
             /* localStorage unavailable — proceed to fetch */
         }
 
-        const response = await fetch(`${API_BASE_URL}/status/overview`);
+        const response = await fetchWithTimeout(`${API_BASE_URL}/status/overview`);
         const json = await response.json();
         if (!json.success) throw new Error(json.error || 'Failed to fetch overview');
 
@@ -77,7 +98,7 @@ const API = {
             /* localStorage unavailable — proceed to fetch */
         }
 
-        const response = await fetch(`${API_BASE_URL}/advisories/active`);
+        const response = await fetchWithTimeout(`${API_BASE_URL}/advisories/active`);
         const json = await response.json();
         if (!json.success) throw new Error(json.error || 'Failed to fetch advisories');
 
@@ -94,7 +115,7 @@ const API = {
      * Get impacted offices (Closed or At Risk)
      */
     async getImpactedOffices() {
-        const response = await fetch(`${API_BASE_URL}/status/offices-impacted`);
+        const response = await fetchWithTimeout(`${API_BASE_URL}/status/offices-impacted`);
         const json = await response.json();
         if (!json.success) throw new Error(json.error || 'Failed to fetch impacted offices');
         return json.data;
@@ -104,7 +125,7 @@ const API = {
      * Get all active government/local notices
      */
     async getActiveNotices() {
-        const response = await fetch(`${API_BASE_URL}/notices/active`);
+        const response = await fetchWithTimeout(`${API_BASE_URL}/notices/active`);
         const json = await response.json();
         if (!json.success) throw new Error(json.error || 'Failed to fetch notices');
         return json.data;
@@ -128,7 +149,7 @@ const API = {
             /* localStorage unavailable — proceed to fetch */
         }
 
-        const response = await fetch(`${API_BASE_URL}/observations`);
+        const response = await fetchWithTimeout(`${API_BASE_URL}/observations`);
         const json = await response.json();
         if (!json.success) throw new Error(json.error || 'Failed to fetch observations');
 
@@ -145,7 +166,7 @@ const API = {
      * Get all offices
      */
     async getOffices() {
-        const response = await fetch(`${API_BASE_URL}/offices`);
+        const response = await fetchWithTimeout(`${API_BASE_URL}/offices`);
         const json = await response.json();
         if (!json.success) throw new Error(json.error || 'Failed to fetch offices');
         return json.data;
@@ -156,7 +177,7 @@ const API = {
      */
     async getTrends(days = 7) {
         try {
-            const response = await fetch(`${API_BASE_URL}/trends?days=${days}`);
+            const response = await fetchWithTimeout(`${API_BASE_URL}/trends?days=${days}`);
             if (!response.ok) throw new Error(`HTTP ${response.status}`);
             const json = await response.json();
             if (!json.success) throw new Error(json.error || 'Failed to fetch trends');
@@ -172,7 +193,7 @@ const API = {
      */
     async getOfficeTrend(officeId, days = 7) {
         try {
-            const response = await fetch(`${API_BASE_URL}/trends/${officeId}?days=${days}`);
+            const response = await fetchWithTimeout(`${API_BASE_URL}/trends/${officeId}?days=${days}`);
             if (!response.ok) throw new Error(`HTTP ${response.status}`);
             const json = await response.json();
             if (!json.success) throw new Error(json.error || 'Failed to fetch office trend');
@@ -188,7 +209,7 @@ const API = {
      */
     async getOfficeHistory(officeId, days = 7) {
         try {
-            const response = await fetch(`${API_BASE_URL}/trends/${officeId}/history?days=${days}`);
+            const response = await fetchWithTimeout(`${API_BASE_URL}/trends/${officeId}/history?days=${days}`);
             if (!response.ok) throw new Error(`HTTP ${response.status}`);
             const json = await response.json();
             if (!json.success) throw new Error(json.error || 'Failed to fetch office history');
@@ -210,7 +231,7 @@ const API = {
      */
     async getOverviewTrends(days = 3) {
         try {
-            const response = await fetch(`${API_BASE_URL}/history/overview-trends?days=${days}`);
+            const response = await fetchWithTimeout(`${API_BASE_URL}/history/overview-trends?days=${days}`);
             return await response.json();
         } catch (error) {
             console.error('Failed to fetch overview trends:', error);
@@ -225,7 +246,7 @@ const API = {
      */
     async getSeverityTrends(days = 3) {
         try {
-            const response = await fetch(`${API_BASE_URL}/history/severity-trends?days=${days}`);
+            const response = await fetchWithTimeout(`${API_BASE_URL}/history/severity-trends?days=${days}`);
             return await response.json();
         } catch (error) {
             console.error('Failed to fetch severity trends:', error);
@@ -241,7 +262,7 @@ const API = {
      */
     async getOfficeTrends(officeId, days = 3) {
         try {
-            const response = await fetch(`${API_BASE_URL}/history/office-trends/${officeId}?days=${days}`);
+            const response = await fetchWithTimeout(`${API_BASE_URL}/history/office-trends/${officeId}?days=${days}`);
             return await response.json();
         } catch (error) {
             console.error(`Failed to fetch office trends for office ${officeId}:`, error);
@@ -255,7 +276,7 @@ const API = {
      */
     async getHistoricalDataAvailability() {
         try {
-            const response = await fetch(`${API_BASE_URL}/history/data-availability`);
+            const response = await fetchWithTimeout(`${API_BASE_URL}/history/data-availability`);
             return await response.json();
         } catch (error) {
             console.error('Failed to check historical data availability:', error);

--- a/frontend/js/page-advisories.js
+++ b/frontend/js/page-advisories.js
@@ -265,8 +265,8 @@ function filterAndRender() {
         return true;
     });
 
-    // Show filter warning
-    renderFilterWarning(allAdvisoriesUnfiltered, filtered);
+    // Show filter warning (shared renderFilterWarning from utils.js)
+    renderFilterWarning(allAdvisoriesUnfiltered, filtered, { onShowAll: showAllAlerts });
 
     // Aggregate by office
     const aggregatedSites = OfficeAggregator.aggregateByOffice(filtered, { deduplicateZones: dedupEnabled });
@@ -277,53 +277,6 @@ function filterAndRender() {
     } else {
         renderGroupedTable(aggregatedSites, filtered);
     }
-}
-
-/**
- * Show or clear the filter-warning banner.
- * The banner is shown when the user's active filter settings hide at least
- * one advisory; it escalates to a critical style when any hidden advisory
- * has Extreme or Severe severity so operators cannot inadvertently miss
- * high-impact events.
- *
- * @param {Array<Object>} allAdv      - Unfiltered advisory list
- * @param {Array<Object>} filteredAdv - Currently visible advisory list after filters
- * @returns {void}
- */
-function renderFilterWarning(allAdv, filteredAdv) {
-    const warning = OfficeAggregator.getFilterWarning(allAdv, filteredAdv);
-    const container = document.getElementById('filterWarningContainer');
-
-    if (!warning) {
-        container.innerHTML = '';
-        return;
-    }
-
-    const criticalClass = warning.has_critical ? 'filter-warning-critical' : '';
-    const criticalText = warning.has_critical ? ` (${warning.critical_hidden} CRITICAL)` : '';
-
-    container.innerHTML = `
-                <div class="col-12">
-                    <div class="filter-warning-banner ${criticalClass}">
-                        <div class="filter-warning-content">
-                            <div class="filter-warning-text">
-                                <span class="filter-warning-icon"><i class="bi bi-exclamation-triangle-fill"></i></span>
-                                <span>
-                                    <strong>Filters Active:</strong> ${warning.hidden_count} alerts hidden${criticalText}
-                                </span>
-                            </div>
-                            <div class="filter-warning-actions">
-                                <button class="btn btn-sm btn-outline-primary" id="showAllAlertsBtn">
-                                    <i class="bi bi-eye"></i> Show All Alerts
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            `;
-
-    // Attach event listener after inserting HTML
-    document.getElementById('showAllAlertsBtn').addEventListener('click', showAllAlerts);
 }
 
 /**

--- a/frontend/js/page-map.js
+++ b/frontend/js/page-map.js
@@ -83,6 +83,9 @@ async function loadMapData() {
         const filteredAdvisories = AlertFilters.filterAdvisories(allAdvisories);
         debugStep('filteredAdvisories: ' + filteredAdvisories.length);
 
+        // Show filter warning if alerts are hidden
+        renderFilterWarning(allAdvisories, filteredAdvisories);
+
         debugStep('Aggregating by office...');
         const aggregated = OfficeAggregator.aggregateByOffice(filteredAdvisories, { deduplicateZones: true });
         debugStep('aggregated offices: ' + aggregated.length);

--- a/frontend/js/page-office-detail.js
+++ b/frontend/js/page-office-detail.js
@@ -70,6 +70,11 @@ async function loadOfficeDetail() {
             return;
         }
 
+        // Show filter warning if user preferences hide some of this office's advisories
+        await AlertFilters.init();
+        const filteredOfficeAdvisories = AlertFilters.filterAdvisories(officeAdvisories);
+        renderFilterWarning(officeAdvisories, filteredOfficeAdvisories);
+
         // Aggregate with deduplication
         const aggregated = OfficeAggregator.aggregateByOffice(officeAdvisories, { deduplicateZones: true });
         const officeAggData = aggregated[0]; // Should only be one office

--- a/frontend/js/page-offices.js
+++ b/frontend/js/page-offices.js
@@ -56,6 +56,11 @@ async function loadOffices() {
         // Apply filters and recalculate advisory counts
         // This will filter to only show offices WITH advisories
         const filteredData = applyFiltersToOffices(offices, advisories);
+
+        // Show filter warning if alerts are hidden
+        const filteredAdvisories = AlertFilters.filterAdvisories(advisories);
+        renderFilterWarning(advisories, filteredAdvisories);
+
         renderOffices(filteredData);
 
         // Populate state filter

--- a/frontend/js/utils.js
+++ b/frontend/js/utils.js
@@ -383,6 +383,66 @@ function debounce(fn, wait) {
 }
 
 /**
+ * Render the filter-warning banner into #filterWarningContainer.
+ * Shows when active filters hide at least one advisory; escalates to critical
+ * style when hidden advisories include Extreme/Severe severity.
+ * When ALL alerts are hidden, shows a distinct "All Alerts Hidden" message.
+ *
+ * @param {Array<Object>} allAdv      - Unfiltered advisory list
+ * @param {Array<Object>} filteredAdv - Currently visible advisory list after filters
+ * @param {Object}        [options]   - Optional configuration
+ * @param {Function}      [options.onShowAll] - Callback for a "Show All Alerts" button;
+ *                                              if omitted, a "Manage Filters" link is shown instead
+ * @returns {void}
+ */
+function renderFilterWarning(allAdv, filteredAdv, options = {}) {
+    const warning = OfficeAggregator.getFilterWarning(allAdv, filteredAdv);
+    const container = document.getElementById('filterWarningContainer');
+    if (!container) return;
+
+    if (!warning) {
+        container.innerHTML = '';
+        return;
+    }
+
+    const criticalClass = warning.has_critical || warning.all_hidden ? 'filter-warning-critical' : '';
+    let messageText;
+    if (warning.all_hidden) {
+        messageText = '<strong>All Alerts Hidden</strong> — no alert types selected';
+    } else {
+        const criticalText = warning.has_critical ? ` (${warning.critical_hidden} CRITICAL)` : '';
+        messageText = `<strong>Filters Active:</strong> ${warning.hidden_count} alerts hidden${criticalText}`;
+    }
+
+    const actionBtn = options.onShowAll
+        ? `<button class="btn btn-sm btn-outline-primary" id="showAllAlertsBtn">
+               <i class="bi bi-eye"></i> Show All Alerts
+           </button>`
+        : `<a class="btn btn-sm btn-outline-primary" href="filters.html">
+               <i class="bi bi-sliders"></i> Manage Filters
+           </a>`;
+
+    container.innerHTML = `
+        <div class="col-12">
+            <div class="filter-warning-banner ${criticalClass}">
+                <div class="filter-warning-content">
+                    <div class="filter-warning-text">
+                        <span class="filter-warning-icon"><i class="bi bi-exclamation-triangle-fill"></i></span>
+                        <span>${messageText}</span>
+                    </div>
+                    <div class="filter-warning-actions">
+                        ${actionBtn}
+                    </div>
+                </div>
+            </div>
+        </div>`;
+
+    if (options.onShowAll) {
+        document.getElementById('showAllAlertsBtn').addEventListener('click', options.onShowAll);
+    }
+}
+
+/**
  * Show a non-intrusive Bootstrap Toast notification. (closes #118)
  * Creates and appends a toast container if one is not already present.
  * @param {string} message - Text to display in the toast

--- a/frontend/map.html
+++ b/frontend/map.html
@@ -42,6 +42,7 @@
     </nav>
 
     <div id="main-content" class="container-fluid mt-4">
+        <div class="row" id="filterWarningContainer"></div>
         <div class="row mb-3">
             <div class="col-12">
                 <h1><i class="bi bi-geo-alt-fill"></i> Map View</h1>

--- a/frontend/office-detail.html
+++ b/frontend/office-detail.html
@@ -38,6 +38,7 @@
     </nav>
 
     <div id="main-content" class="container-fluid mt-4">
+        <div class="row" id="filterWarningContainer"></div>
         <!-- Breadcrumb Navigation -->
         <div class="row mb-3">
             <div class="col-12">

--- a/frontend/offices.html
+++ b/frontend/offices.html
@@ -38,6 +38,7 @@
     </nav>
 
     <div id="main-content" class="container-fluid mt-4">
+        <div class="row" id="filterWarningContainer"></div>
         <div class="row mb-4">
             <div class="col-12">
                 <h1>Offices Impacted</h1>


### PR DESCRIPTION
## Summary

- **#258**: Add 30s `AbortController` timeout to all frontend `fetch()` calls in `api.js` — prevents page hang when backend is unresponsive
- **#261**: Fix filter warning to show "All Alerts Hidden — no alert types selected" when every alert type is deselected
- **#262**: Extract `renderFilterWarning` to shared `utils.js` and add the banner to map, offices, and office-detail pages (safety concern — ops team could miss tornado warnings)
- **#259**: Replace `setTimeout(5000)` with chaining initial snapshot off ingestion `.finally()`, eliminating the startup race condition
- **#269**: Add Prometheus `/metrics` endpoint via `prom-client` with: `http_requests_total`, `http_request_duration_seconds`, `ingestion_cycle_duration_seconds`, `ingestion_advisories_total`, `cache_hits_total`/`cache_misses_total`, `circuit_breaker_state`, `db_pool_active_connections`, plus default Node.js metrics

Closes #258 Closes #259 Closes #261 Closes #262 Closes #269

## Test plan

- [x] All 129 backend tests pass
- [ ] Verify fetch timeout: stop backend, confirm frontend shows error after 30s instead of hanging
- [ ] Verify filter warning appears on map, offices, and office-detail pages when filters hide alerts
- [ ] Verify "All Alerts Hidden" message when all alert types are deselected
- [ ] Verify `/metrics` returns Prometheus-format metrics
- [ ] Verify initial snapshot runs only after ingestion completes (check startup logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)