### PR TITLE
fix: resolve ER_DUP_ENTRY race and help-icon keyboard a11y

### DIFF
--- a/backend/src/models/advisory.js
+++ b/backend/src/models/advisory.js
@@ -342,15 +342,21 @@ const AdvisoryModel = {
                     : JSON.stringify(advisory.raw_payload)
                 : null;
 
-            // Insert new alert (or update by external_id if duplicate external_id)
+            // Upsert: INSERT with ON DUPLICATE KEY UPDATE eliminates the TOCTOU
+            // race window between the SELECT checks above and this write.
+            // Both unique constraints (external_id+office_id and vtec_event_unique_key)
+            // are covered — if a concurrent insert wins, the upsert merges cleanly.
+            // `id = LAST_INSERT_ID(id)` ensures result.insertId returns the correct
+            // row ID regardless of whether an INSERT or UPDATE occurred. (closes #260)
             const [result] = await db.query(
                 `
         INSERT INTO advisories (
           external_id, office_id, advisory_type, severity, status, source,
-          headline, description, start_time, end_time, issued_time, 
+          headline, description, start_time, end_time, issued_time,
           vtec_code, vtec_event_id, vtec_action, raw_payload
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON DUPLICATE KEY UPDATE
+          id = LAST_INSERT_ID(id),
           office_id = VALUES(office_id),
           advisory_type = VALUES(advisory_type),
           severity = VALUES(severity),
@@ -386,25 +392,8 @@ const AdvisoryModel = {
                 ]
             );
 
-            return this.getById(result.insertId || result.lastInsertId || advisory.id);
+            return this.getById(result.insertId);
         } catch (error) {
-            // Handle unique constraint violation (ER_DUP_ENTRY)
-            // This can happen if a duplicate event is inserted between the findByVTECEventID check and insert
-            if (error.code === 'ER_DUP_ENTRY' && advisory.vtec_event_id) {
-                console.log(
-                    `Duplicate event detected via constraint: ${advisory.vtec_event_id} [${advisory.vtec_action}] - fetching existing alert`
-                );
-                // Find and return the existing alert
-                const existing = await this.findByVTECEventID(
-                    advisory.vtec_event_id,
-                    advisory.office_id,
-                    advisory.advisory_type
-                );
-                if (existing) {
-                    // Update it with the new data
-                    return this.update(existing.id, advisory);
-                }
-            }
             console.error('Error creating advisory:', error);
             throw error;
         }

--- a/frontend/css/tooltips.css
+++ b/frontend/css/tooltips.css
@@ -71,9 +71,10 @@
     border-top-color: #1a1a1a;
 }
 
-/* Show tooltip on hover/focus */
+/* Show tooltip on hover/focus/active (keyboard toggle) */
 .help-icon:hover + .tooltip-content,
 .help-icon:focus + .tooltip-content,
+.help-icon[aria-expanded="true"] + .tooltip-content,
 .tooltip-content:hover {
     opacity: 1;
     visibility: visible;
@@ -97,7 +98,8 @@
 }
 
 .help-icon:hover + .tooltip-content.tooltip-right,
-.help-icon:focus + .tooltip-content.tooltip-right {
+.help-icon:focus + .tooltip-content.tooltip-right,
+.help-icon[aria-expanded="true"] + .tooltip-content.tooltip-right {
     transform: translateX(12px) translateY(-50%);
 }
 

--- a/frontend/js/page-index.js
+++ b/frontend/js/page-index.js
@@ -451,6 +451,9 @@ AlertFilters.init().then(() => {
     loadOverview();
 });
 
+// Enable keyboard activation for help-icon tooltips (WCAG 2.1.1)
+initHelpIconKeyboard();
+
 // Helper function to export current dashboard data
 window.exportCurrentData = async function (type) {
     try {

--- a/frontend/js/utils.js
+++ b/frontend/js/utils.js
@@ -443,6 +443,34 @@ function renderFilterWarning(allAdv, filteredAdv, options = {}) {
 }
 
 /**
+ * Initialise keyboard support for help-icon tooltip toggles. (closes #263)
+ * WCAG 2.1.1 requires all interactive elements to be keyboard-operable.
+ * Help icons have role="button", so Enter and Space must activate them.
+ * Pressing Enter/Space toggles aria-expanded and a persistent visible state;
+ * pressing Escape or blurring the icon dismisses the tooltip.
+ */
+function initHelpIconKeyboard() {
+    document.querySelectorAll('.help-icon[role="button"]').forEach((icon) => {
+        icon.setAttribute('aria-expanded', 'false');
+
+        icon.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                const expanded = icon.getAttribute('aria-expanded') === 'true';
+                icon.setAttribute('aria-expanded', String(!expanded));
+            } else if (e.key === 'Escape') {
+                icon.setAttribute('aria-expanded', 'false');
+                icon.blur();
+            }
+        });
+
+        icon.addEventListener('blur', () => {
+            icon.setAttribute('aria-expanded', 'false');
+        });
+    });
+}
+
+/**
  * Show a non-intrusive Bootstrap Toast notification. (closes #118)
  * Creates and appends a toast container if one is not already present.
  * @param {string} message - Text to display in the toast


### PR DESCRIPTION
## Summary
- **#260**: Add `id = LAST_INSERT_ID(id)` to the advisory upsert's `ON DUPLICATE KEY UPDATE` clause for reliable row ID retrieval. Remove the now-redundant `ER_DUP_ENTRY` catch-and-retry block — the upsert handles both unique constraints (external_id+office_id and vtec_event_unique_key) atomically.
- **#263**: Add `initHelpIconKeyboard()` to attach Enter/Space keydown listeners to `.help-icon[role="button"]` elements, toggling `aria-expanded` and tooltip visibility per WCAG 2.1.1. Escape and blur dismiss the tooltip. CSS updated to support `[aria-expanded="true"]` selector.

Closes #260, closes #263

## Test plan
- [x] All 129 backend tests pass
- [ ] Verify advisory upsert works correctly with concurrent inserts
- [ ] Tab to help icons on dashboard — tooltip shows on focus
- [ ] Press Enter/Space on focused help icon — tooltip toggles
- [ ] Press Escape — tooltip dismisses
- [ ] Screen reader announces expanded/collapsed state

🤖 Generated with [Claude Code](https://claude.com/claude-code)