### PR TITLE
refactor: DB ingestion tracking, simplified dedup, geo pre-filter, payload cleanup

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -7,10 +7,10 @@ const express = require('express');
 const compression = require('compression');
 const cors = require('cors');
 const helmet = require('helmet');
-const fs = require('fs');
 const path = require('path');
 const config = require('./config/config');
 const { getDatabase } = require('./config/database');
+const IngestionEvent = require('./models/ingestionEvent');
 const { apiLimiter, writeLimiter, authLimiter } = require('./middleware/rateLimiter');
 const { requireApiKey } = require('./middleware/apiKey');
 const { metricsMiddleware, mountMetricsEndpoint } = require('./middleware/metrics');
@@ -194,16 +194,16 @@ app.get('/health', async (req, res) => {
 });
 
 // X-Data-Age header — tells the frontend how old the data is (seconds since last ingestion)
-app.use('/api', (req, res, next) => {
+// Reads from the ingestion_events DB table instead of .last-ingestion.json. (closes #264)
+app.use('/api', async (req, res, next) => {
     try {
-        const ingestionFile = path.join(__dirname, '../.last-ingestion.json');
-        if (fs.existsSync(ingestionFile)) {
-            const data = JSON.parse(fs.readFileSync(ingestionFile, 'utf8'));
-            const ageSec = Math.round((Date.now() - new Date(data.lastUpdated).getTime()) / 1000);
+        const last = await IngestionEvent.getLastSuccessful();
+        if (last) {
+            const ageSec = last.minutesAgo * 60;
             res.setHeader('X-Data-Age', String(ageSec));
         }
     } catch (_) {
-        /* non-critical */
+        /* non-critical — table may not exist yet */
     }
     next();
 });

--- a/backend/src/data/schema.sql
+++ b/backend/src/data/schema.sql
@@ -286,6 +286,22 @@ CREATE TABLE IF NOT EXISTS system_snapshots (
 
 CREATE INDEX idx_system_snapshots_time ON system_snapshots(snapshot_time);
 
+-- Ingestion event log — replaces file-based .last-ingestion.json tracking.
+-- Records every ingestion cycle (success or failure) for monitoring,
+-- X-Data-Age calculation, and the /api/admin/health endpoint.
+CREATE TABLE IF NOT EXISTS ingestion_events (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    started_at DATETIME NOT NULL,
+    completed_at DATETIME,
+    status ENUM('running', 'success', 'failure') NOT NULL DEFAULT 'running',
+    advisories_created INT DEFAULT 0,
+    advisories_expired INT DEFAULT 0,
+    error_message TEXT,
+    duration_ms INT,
+    INDEX idx_ingestion_status (status),
+    INDEX idx_ingestion_completed (completed_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 -- Migration version tracking table
 -- Records every forward migration that has been applied to this database.
 -- Managed by: node src/scripts/run-migrations.js

--- a/backend/src/ingestion/noaa-ingestor.js
+++ b/backend/src/ingestion/noaa-ingestor.js
@@ -4,8 +4,6 @@
  * Features: transactions, UGC-level geo-matching, deduplication
  */
 
-const fs = require('fs');
-const path = require('path');
 const { getNOAAAlerts, getLatestObservation } = require('./utils/api-client');
 const {
     normalizeNOAAAlert,
@@ -21,8 +19,7 @@ const { removeExpiredAdvisories } = require('../utils/cleanup-advisories');
 const { alertAnomaly } = require('../utils/alerting');
 const ObservationModel = require('../models/observation');
 const cache = require('../utils/cache');
-
-const LAST_INGESTION_FILE = path.join(__dirname, '../../.last-ingestion.json');
+const IngestionEvent = require('../models/ingestionEvent');
 
 // Ingestion status tracking — exposed via getIngestionStatus()
 let isIngesting = false;
@@ -48,6 +45,15 @@ async function ingestNOAAData() {
 
     isIngesting = true;
     ingestionStartedAt = new Date().toISOString();
+    const ingestionStart = Date.now();
+
+    // Record ingestion start in the DB event log (replaces .last-ingestion.json)
+    let ingestionEventId = null;
+    try {
+        ingestionEventId = await IngestionEvent.recordStart();
+    } catch (_) {
+        /* table may not exist yet on first run */
+    }
 
     try {
         // Step 1: Fetch all active NOAA alerts
@@ -218,33 +224,28 @@ async function ingestNOAAData() {
         try {
             await connection.beginTransaction();
 
-            // Bulk pre-fetch all existing active advisories for the affected offices.
+            // Bulk pre-fetch existing active advisories by external_id for the affected offices.
             // Runs inside the transaction on the same connection for read consistency.
-            // Eliminates per-row SELECT queries in the insert loop (2 SELECTs × N → 1 query).
+            // VTEC-based dedup is handled atomically by INSERT ON DUPLICATE KEY UPDATE,
+            // so only the external_id lookup map is needed here. (closes #265)
             const existingByExternalId = new Map();
-            const existingByVtec = new Map();
             const affectedOfficeIds = Array.from(officeAdvisories.keys());
 
             if (affectedOfficeIds.length > 0) {
                 const [existingRows] = await connection.query(
-                    `SELECT id, external_id, vtec_event_id, advisory_type, office_id
+                    `SELECT id, external_id, office_id
            FROM advisories
-           WHERE office_id IN (?) AND status = 'active'`,
+           WHERE office_id IN (?) AND status = 'active' AND external_id IS NOT NULL`,
                     [affectedOfficeIds]
                 );
                 for (const row of existingRows) {
-                    if (row.external_id) {
-                        existingByExternalId.set(`${row.external_id}|${row.office_id}`, row);
-                    }
-                    if (row.vtec_event_id) {
-                        existingByVtec.set(`${row.vtec_event_id}|${row.office_id}|${row.advisory_type}`, row);
-                    }
+                    existingByExternalId.set(`${row.external_id}|${row.office_id}`, row);
                 }
                 console.log(
                     `Pre-fetched ${existingRows.length} existing advisories for ${affectedOfficeIds.length} offices`
                 );
             }
-            const existingLookup = { byExternalId: existingByExternalId, byVtec: existingByVtec };
+            const existingLookup = { byExternalId: existingByExternalId };
 
             // Create/update advisories and track processed external IDs
             for (const [officeId, advisories] of officeAdvisories.entries()) {
@@ -458,9 +459,18 @@ async function ingestNOAAData() {
             console.warn('[CACHE] Pre-warm failed (non-fatal):', warmErr.message);
         }
 
-        // Save timestamp of successful ingestion
-        const timestamp = new Date().toISOString();
-        fs.writeFileSync(LAST_INGESTION_FILE, JSON.stringify({ lastUpdated: timestamp }));
+        // Record successful ingestion in the DB event log
+        if (ingestionEventId) {
+            try {
+                await IngestionEvent.recordSuccess(ingestionEventId, {
+                    advisoriesCreated,
+                    advisoriesExpired: expiredCount,
+                    durationMs: Date.now() - ingestionStart
+                });
+            } catch (_) {
+                /* non-critical */
+            }
+        }
 
         const totalFailed = advisoriesFailed + statusesFailed;
         const logSummary = totalFailed > 0 ? console.warn : console.log;
@@ -494,6 +504,13 @@ async function ingestNOAAData() {
         };
     } catch (error) {
         console.error('\n✗ NOAA ingestion failed:', error.message);
+        if (ingestionEventId) {
+            try {
+                await IngestionEvent.recordFailure(ingestionEventId, error.message, Date.now() - ingestionStart);
+            } catch (_) {
+                /* non-critical */
+            }
+        }
         throw error;
     } finally {
         isIngesting = false;
@@ -723,19 +740,17 @@ function stateNameToCode(name) {
 }
 
 /**
- * Get last ingestion timestamp
- * @returns {Object|null} {lastUpdated: ISO string} or null if never run
+ * Get last successful ingestion timestamp from the DB event log.
+ * @returns {Promise<Object|null>} {lastUpdated: ISO string} or null if never run
  */
-function getLastIngestionTime() {
+async function getLastIngestionTime() {
     try {
-        if (fs.existsSync(LAST_INGESTION_FILE)) {
-            const data = fs.readFileSync(LAST_INGESTION_FILE, 'utf8');
-            return JSON.parse(data);
-        }
-    } catch (error) {
-        console.error('Error reading last ingestion time:', error);
+        const result = await IngestionEvent.getLastSuccessful();
+        return result ? { lastUpdated: result.lastUpdated } : null;
+    } catch (_) {
+        /* table may not exist yet */
+        return null;
     }
-    return null;
 }
 
 module.exports = {

--- a/backend/src/ingestion/utils/normalizer.js
+++ b/backend/src/ingestion/utils/normalizer.js
@@ -175,7 +175,13 @@ function normalizeNOAAAlert(noaaAlert) {
     const vtecCode = extractVTEC(noaaAlert);
     const alertType = properties.event || 'Weather Advisory';
 
+    // Extract external_id upfront so it's always populated. NOAA GeoJSON features
+    // always include an `id` field (or `properties.id`). Extracting here instead of
+    // deferring to advisory.create() simplifies the dedup strategy. (closes #265)
+    const externalId = noaaAlert.id || properties.id || null;
+
     return {
+        external_id: externalId,
         advisory_type: alertType,
         // Use internal category-based severity (operational alignment)
         // instead of NOAA's raw severity field

--- a/backend/src/models/advisory.js
+++ b/backend/src/models/advisory.js
@@ -279,7 +279,8 @@ const AdvisoryModel = {
     async create(advisory, existingLookup = null) {
         const db = getDatabase();
         try {
-            // Extract external_id early for deduplication check
+            // Extract external_id — normalizer now populates this upfront, but
+            // fall back to raw_payload extraction for direct callers. (closes #265)
             let externalId = advisory.external_id;
             if (!externalId && advisory.raw_payload) {
                 const payload =
@@ -287,7 +288,11 @@ const AdvisoryModel = {
                 externalId = payload.id || payload.properties?.id;
             }
 
-            // Primary deduplication: Check by external_id + office_id (composite unique)
+            // Primary deduplication: Check by external_id + office_id (composite unique).
+            // This is the single authoritative dedup path. VTEC-based dedup is handled
+            // atomically by the INSERT ON DUPLICATE KEY UPDATE below (via the
+            // idx_vtec_event_unique_active constraint), eliminating the need for an
+            // explicit SELECT-then-UPDATE for VTEC matches.
             if (externalId) {
                 const existing = existingLookup
                     ? existingLookup.byExternalId.get(`${externalId}|${advisory.office_id}`) || null
@@ -301,7 +306,7 @@ const AdvisoryModel = {
                 }
             }
 
-            // Secondary deduplication: natural key when both external_id and VTEC are absent.
+            // Safety-net deduplication: natural key when both external_id and VTEC are absent.
             // Malformed/legacy NOAA payloads may omit both fields; without this guard a
             // retry of the same payload produces a duplicate row. (closes #114)
             if (!externalId && !advisory.vtec_event_id) {
@@ -314,22 +319,6 @@ const AdvisoryModel = {
                 if (existing) {
                     console.warn(
                         `[Advisory] Fallback natural-key dedup matched existing #${existing.id} (no external_id/VTEC). Updating instead of inserting.`
-                    );
-                    return this.update(existing.id, advisory);
-                }
-            }
-
-            // Tertiary deduplication: VTEC Event ID (persistent across NEW→CON→EXT updates)
-            if (advisory.vtec_event_id) {
-                const vtecKey = `${advisory.vtec_event_id}|${advisory.office_id}|${advisory.advisory_type}`;
-                const existing = existingLookup
-                    ? existingLookup.byVtec.get(vtecKey) || null
-                    : await this.findByVTECEventID(advisory.vtec_event_id, advisory.office_id, advisory.advisory_type);
-
-                if (existing) {
-                    const action = advisory.vtec_action || 'UNK';
-                    console.log(
-                        `Updating existing event via VTEC [${action}]: ${advisory.vtec_event_id} for office ${advisory.office_id}`
                     );
                     return this.update(existing.id, advisory);
                 }

--- a/backend/src/models/ingestionEvent.js
+++ b/backend/src/models/ingestionEvent.js
@@ -1,0 +1,77 @@
+/**
+ * Ingestion Event Model
+ * Replaces file-based .last-ingestion.json with transactional DB tracking.
+ * Records start/end/status of each ingestion cycle. (closes #264)
+ */
+
+const { getDatabase } = require('../config/database');
+
+const IngestionEvent = {
+    /**
+     * Record the start of an ingestion cycle.
+     * @returns {Promise<number>} The inserted event ID
+     */
+    async recordStart() {
+        const db = getDatabase();
+        const [result] = await db.query(`INSERT INTO ingestion_events (started_at, status) VALUES (NOW(), 'running')`);
+        return result.insertId;
+    },
+
+    /**
+     * Record a successful ingestion cycle.
+     * @param {number} eventId - The event ID from recordStart()
+     * @param {Object} stats - Ingestion statistics
+     * @param {number} stats.advisoriesCreated
+     * @param {number} stats.advisoriesExpired
+     * @param {number} stats.durationMs
+     */
+    async recordSuccess(eventId, { advisoriesCreated = 0, advisoriesExpired = 0, durationMs = 0 } = {}) {
+        const db = getDatabase();
+        await db.query(
+            `UPDATE ingestion_events
+             SET status = 'success', completed_at = NOW(),
+                 advisories_created = ?, advisories_expired = ?, duration_ms = ?
+             WHERE id = ?`,
+            [advisoriesCreated, advisoriesExpired, durationMs, eventId]
+        );
+    },
+
+    /**
+     * Record a failed ingestion cycle.
+     * @param {number} eventId - The event ID from recordStart()
+     * @param {string} errorMessage - Error description
+     * @param {number} durationMs - Elapsed time in milliseconds
+     */
+    async recordFailure(eventId, errorMessage, durationMs = 0) {
+        const db = getDatabase();
+        await db.query(
+            `UPDATE ingestion_events
+             SET status = 'failure', completed_at = NOW(),
+                 error_message = ?, duration_ms = ?
+             WHERE id = ?`,
+            [errorMessage, durationMs, eventId]
+        );
+    },
+
+    /**
+     * Get the last successful ingestion timestamp.
+     * Used by X-Data-Age header and health checks.
+     * @returns {Promise<{lastUpdated: string, minutesAgo: number}|null>}
+     */
+    async getLastSuccessful() {
+        const db = getDatabase();
+        const [rows] = await db.query(
+            `SELECT completed_at FROM ingestion_events
+             WHERE status = 'success'
+             ORDER BY completed_at DESC LIMIT 1`
+        );
+        if (!rows.length || !rows[0].completed_at) return null;
+        const completed = new Date(rows[0].completed_at);
+        return {
+            lastUpdated: completed.toISOString(),
+            minutesAgo: Math.round((Date.now() - completed.getTime()) / 60000)
+        };
+    }
+};
+
+module.exports = IngestionEvent;

--- a/backend/src/models/office.js
+++ b/backend/src/models/office.js
@@ -92,7 +92,12 @@ const OfficeModel = {
      */
     async findNearby(lat, lon, radiusMiles = 50) {
         const db = getDatabase();
-        // Using Haversine formula approximation
+        // Bounding box pre-filter uses the idx_offices_coords index to eliminate
+        // most rows before the expensive Haversine trig runs. 1 degree of latitude
+        // ≈ 69 miles; longitude varies by cos(lat). (closes #266)
+        const latDelta = radiusMiles / 69.0;
+        const lonDelta = radiusMiles / (69.0 * Math.cos((lat * Math.PI) / 180));
+
         const query = `
       SELECT *,
         (3959 * acos(
@@ -101,14 +106,28 @@ const OfficeModel = {
           sin(radians(?)) * sin(radians(latitude))
         )) AS distance
       FROM offices
-      WHERE (3959 * acos(
-        cos(radians(?)) * cos(radians(latitude)) *
-        cos(radians(longitude) - radians(?)) +
-        sin(radians(?)) * sin(radians(latitude))
-      )) <= ?
+      WHERE latitude BETWEEN ? AND ?
+        AND longitude BETWEEN ? AND ?
+        AND (3959 * acos(
+          cos(radians(?)) * cos(radians(latitude)) *
+          cos(radians(longitude) - radians(?)) +
+          sin(radians(?)) * sin(radians(latitude))
+        )) <= ?
       ORDER BY distance
     `;
-        const [rows] = await db.query(query, [lat, lon, lat, lat, lon, lat, radiusMiles]);
+        const [rows] = await db.query(query, [
+            lat,
+            lon,
+            lat,
+            lat - latDelta,
+            lat + latDelta,
+            lon - lonDelta,
+            lon + lonDelta,
+            lat,
+            lon,
+            lat,
+            radiusMiles
+        ]);
         return rows;
     },
 

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -96,12 +96,11 @@ router.get('/status', (req, res) => {
  * The public /health endpoint returns only status (ok/degraded) for load balancers.
  */
 router.get('/health', async (req, res) => {
-    const fs = require('fs');
-    const path = require('path');
     const { getDatabase } = require('../config/database');
     const config = require('../config/config');
     const { getIngestionStatus } = require('../ingestion/noaa-ingestor');
     const { getCircuitBreakerState } = require('../ingestion/utils/api-client');
+    const IngestionEvent = require('../models/ingestionEvent');
 
     const mem = process.memoryUsage();
 
@@ -149,23 +148,19 @@ router.get('/health', async (req, res) => {
     }
 
     try {
-        const ingestionFile = path.join(__dirname, '../../.last-ingestion.json');
-        if (fs.existsSync(ingestionFile)) {
-            const data = JSON.parse(fs.readFileSync(ingestionFile, 'utf8'));
-            const lastUpdate = new Date(data.lastUpdated);
-            const minutesAgo = (Date.now() - lastUpdate.getTime()) / (1000 * 60);
-
+        const last = await IngestionEvent.getLastSuccessful();
+        if (last) {
             health.checks.ingestion = {
-                status: minutesAgo <= 30 ? 'ok' : 'stale',
-                lastUpdated: data.lastUpdated,
-                minutesAgo: Math.round(minutesAgo),
+                status: last.minutesAgo <= 30 ? 'ok' : 'stale',
+                lastUpdated: last.lastUpdated,
+                minutesAgo: last.minutesAgo,
                 message:
-                    minutesAgo <= 30
+                    last.minutesAgo <= 30
                         ? 'Ingestion is current'
-                        : `Last ingestion was ${Math.round(minutesAgo)} minutes ago (expected: <= 30 min)`
+                        : `Last ingestion was ${last.minutesAgo} minutes ago (expected: <= 30 min)`
             };
 
-            if (minutesAgo > 30) {
+            if (last.minutesAgo > 30) {
                 health.status = 'degraded';
             }
         } else {

--- a/backend/src/utils/cleanup-advisories.js
+++ b/backend/src/utils/cleanup-advisories.js
@@ -236,6 +236,37 @@ async function markExpiredByEndTime() {
 }
 
 /**
+ * NULL out raw_payload for advisories older than the retention period.
+ * Advisories that still lack an external_id are skipped (payload is needed
+ * for backfill). Default retention: 90 days. (closes #268)
+ *
+ * @param {number} retentionDays - Days to keep raw payloads (default 90)
+ * @returns {Promise<number>} Number of payloads nullified
+ */
+async function nullifyStaleRawPayloads(retentionDays = 90) {
+    const db = getDatabase();
+
+    console.log(`\n=== Nullifying Raw Payloads Older Than ${retentionDays} Days ===`);
+
+    const [result] = await db.query(
+        `UPDATE advisories
+         SET raw_payload = NULL
+         WHERE raw_payload IS NOT NULL
+           AND external_id IS NOT NULL
+           AND last_updated < DATE_SUB(NOW(), INTERVAL ? DAY)`,
+        [retentionDays]
+    );
+
+    const count = result.affectedRows || 0;
+    if (count > 0) {
+        console.log(`✓ Nullified ${count} stale raw payloads (>${retentionDays} days old)`);
+    } else {
+        console.log('✓ No stale raw payloads to clean up');
+    }
+    return count;
+}
+
+/**
  * Remove expired advisories (batched)
  */
 async function removeExpiredAdvisories() {
@@ -400,6 +431,7 @@ async function runCleanup(mode = 'full', options = {}) {
         typeDuplicates: 0,
         expiredRemoved: 0,
         externalIdsPopulated: 0,
+        rawPayloadsNullified: 0,
         totalRemoved: 0,
         success: true,
         error: null
@@ -426,6 +458,11 @@ async function runCleanup(mode = 'full', options = {}) {
                 results.vtecCodeDuplicates = await removeDuplicatesByVTECCode();
                 results.typeDuplicates = await removeDuplicateTypes();
                 results.expiredRemoved = await removeExpiredAdvisories();
+                results.rawPayloadsNullified = await nullifyStaleRawPayloads();
+                break;
+
+            case 'payloads':
+                results.rawPayloadsNullified = await nullifyStaleRawPayloads(options.retentionDays || 90);
                 break;
 
             case 'vtec':
@@ -483,6 +520,9 @@ async function runCleanup(mode = 'full', options = {}) {
         if (results.expiredRemoved > 0) {
             log(`║  Expired removed:        ${results.expiredRemoved.toString().padStart(23)} ║`);
         }
+        if (results.rawPayloadsNullified > 0) {
+            log(`║  Payloads nullified:     ${results.rawPayloadsNullified.toString().padStart(23)} ║`);
+        }
         log(`║  Total removed:          ${results.totalRemoved.toString().padStart(23)} ║`);
         log('╚══════════════════════════════════════════════════════╝\n');
     } catch (error) {
@@ -511,6 +551,7 @@ if (require.main === module) {
 module.exports = {
     runCleanup,
     removeExpiredAdvisories,
+    nullifyStaleRawPayloads,
     markExpiredByEndTime,
     removeDuplicatesByExternalId,
     removeDuplicatesByVTECEventId,

--- a/backend/tests/unit/advisory.model.test.js
+++ b/backend/tests/unit/advisory.model.test.js
@@ -68,24 +68,22 @@ describe('AdvisoryModel.create() — deduplication', () => {
     updateSpy.mockRestore();
   });
 
-  test('updates existing advisory when VTEC event ID matches (no external_id)', async () => {
+  test('VTEC dedup handled atomically by INSERT ON DUPLICATE KEY UPDATE (no explicit SELECT)', async () => {
+    // When external_id is null but vtec_event_id is present, the explicit VTEC
+    // SELECT-then-UPDATE path is no longer used. Instead, the INSERT ON DUPLICATE
+    // KEY UPDATE fires on the vtec_event_unique_key constraint. (closes #265)
     const advisory = { ...BASE_ADVISORY, external_id: null };
-    const existing = { id: 55, ...advisory };
+    const newRow = { id: 55, ...advisory };
 
     const db = makeDb([
-      [[existing], {}],  // findByVTECEventID SELECT
-      [{}, {}],          // UPDATE
-      [[existing], {}]   // getById
+      [{ insertId: 55 }, {}],  // INSERT ON DUPLICATE KEY UPDATE (upsert)
+      [[newRow], {}]           // getById
     ]);
     getDatabase.mockReturnValue(db);
 
-    const updateSpy = jest.spyOn(AdvisoryModel, 'update').mockResolvedValue(existing);
-
     const result = await AdvisoryModel.create(advisory);
 
-    expect(updateSpy).toHaveBeenCalledWith(55, expect.any(Object));
-
-    updateSpy.mockRestore();
+    expect(result).toEqual(newRow);
   });
 
   test('uses natural-key dedup and updates when both external_id and VTEC are null (closes #114)', async () => {
@@ -114,8 +112,7 @@ describe('AdvisoryModel.create() — deduplication', () => {
 
     const db = makeDb([
       [[], {}],                      // findByExternalID → not found
-      [[], {}],                      // findByVTECEventID → not found
-      [{ insertId: 99 }, {}],        // INSERT
+      [{ insertId: 99 }, {}],        // INSERT ON DUPLICATE KEY UPDATE
       [[newRow], {}]                 // getById
     ]);
     getDatabase.mockReturnValue(db);


### PR DESCRIPTION
## Summary
- **#264**: Replace `.last-ingestion.json` with an `ingestion_events` DB table. Records start/end/status/stats for each ingestion cycle. X-Data-Age header and `/api/admin/health` now query the DB instead of reading a file, making the state transactional and queryable.
- **#265**: Simplify three-tier advisory dedup to a single external_id path. The normalizer now extracts `external_id` upfront (NOAA always provides it). VTEC dedup handled atomically by `INSERT ON DUPLICATE KEY UPDATE` via the `vtec_event_unique_key` constraint. Natural-key dedup remains as a safety net.
- **#266**: Add bounding-box pre-filter to `findNearby()` using the existing `idx_offices_coords` index to eliminate most rows before the Haversine formula runs.
- **#268**: Add `nullifyStaleRawPayloads()` to NULL out `raw_payload` for advisories older than 90 days. Integrated into full cleanup mode and available as standalone `payloads` mode.

Closes #264, closes #265, closes #266, closes #268

## Test plan
- [x] All 129 backend tests pass
- [ ] Verify `ingestion_events` table gets populated after an ingestion cycle
- [ ] Verify X-Data-Age header still works correctly
- [ ] Verify `/api/admin/health` ingestion check uses DB
- [ ] Verify advisory upsert still handles VTEC CON/EXT updates correctly
- [ ] Run `node src/scripts/scheduled-cleanup.js payloads` to test payload cleanup
- [ ] Run `node src/scripts/scheduled-cleanup.js full` to verify full cleanup includes payload nullification

🤖 Generated with [Claude Code](https://claude.com/claude-code)