### PR TITLE
feat: audit logging, E2E tests, automated DB backup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ temp/
 
 # Backup files
 *backup*
+!deployment/backup.sh
+!deployment/verify-backup.sh
 *-stub.js
 *.bak
 *-sqljs*

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -377,6 +377,42 @@ systemctl --user restart storm-scout-dev
 
 ---
 
+## Database Backups
+
+### Setup
+
+1. Configure backup environment variables in your `.env` or cron environment:
+   ```bash
+   export DB_HOST=localhost
+   export DB_PORT=3306
+   export DB_USER=storm_scout
+   export DB_PASSWORD=your_password
+   export DB_NAME=storm_scout
+   export BACKUP_DIR=/var/backups/storm-scout
+   export RETENTION_DAYS=30
+   ```
+
+2. Schedule daily backups and weekly verification:
+   ```bash
+   # Daily backup at 2 AM
+   0 2 * * * /path/to/deployment/backup.sh >> /var/log/storm-scout-backup.log 2>&1
+
+   # Weekly verification (Sunday at 4 AM)
+   0 4 * * 0 /path/to/deployment/verify-backup.sh >> /var/log/storm-scout-verify.log 2>&1
+   ```
+
+3. Test manually:
+   ```bash
+   ./deployment/backup.sh
+   ./deployment/verify-backup.sh
+   ```
+
+### Recovery
+
+See [docs/ARCHITECTURE.md — Backup & Recovery](docs/ARCHITECTURE.md#backup--recovery) for RTO/RPO targets and restore procedure.
+
+---
+
 ## Environment Variables (`.env`)
 
 | Variable | Description | Example |

--- a/backend/src/data/migrations/20260314-add-audit-log.sql
+++ b/backend/src/data/migrations/20260314-add-audit-log.sql
@@ -1,0 +1,11 @@
+-- Add audit_log table for admin action tracking (closes #267)
+CREATE TABLE IF NOT EXISTS audit_log (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    action VARCHAR(100) NOT NULL,
+    actor VARCHAR(100) NOT NULL DEFAULT 'api_key',
+    detail TEXT,
+    ip_address VARCHAR(45),
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_audit_action (action),
+    INDEX idx_audit_created (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/backend/src/data/schema.sql
+++ b/backend/src/data/schema.sql
@@ -302,6 +302,19 @@ CREATE TABLE IF NOT EXISTS ingestion_events (
     INDEX idx_ingestion_completed (completed_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+-- Audit log — records administrative actions for governance and debugging.
+-- Tracks who (actor) did what (action) and when, with optional detail payload.
+CREATE TABLE IF NOT EXISTS audit_log (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    action VARCHAR(100) NOT NULL,          -- e.g., 'pause_ingestion', 'resume_ingestion', 'cleanup'
+    actor VARCHAR(100) NOT NULL DEFAULT 'api_key', -- Role/system identifier (not PII)
+    detail TEXT,                            -- JSON string with action-specific context
+    ip_address VARCHAR(45),                -- Client IP (supports IPv6)
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_audit_action (action),
+    INDEX idx_audit_created (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 -- Migration version tracking table
 -- Records every forward migration that has been applied to this database.
 -- Managed by: node src/scripts/run-migrations.js

--- a/backend/src/models/auditLog.js
+++ b/backend/src/models/auditLog.js
@@ -1,0 +1,40 @@
+/**
+ * Audit Log Model
+ * Records administrative actions for governance and debugging. (closes #267)
+ */
+
+const { getDatabase } = require('../config/database');
+
+const AuditLog = {
+    /**
+     * Record an administrative action.
+     * @param {Object} entry
+     * @param {string} entry.action - Action identifier (e.g., 'pause_ingestion')
+     * @param {string} [entry.actor='api_key'] - Role or system identifier (not PII)
+     * @param {Object|string} [entry.detail] - Action-specific context (serialized to JSON)
+     * @param {string} [entry.ipAddress] - Client IP address
+     * @returns {Promise<number>} The inserted log entry ID
+     */
+    async record({ action, actor = 'api_key', detail = null, ipAddress = null }) {
+        const db = getDatabase();
+        const detailJson = detail && typeof detail === 'object' ? JSON.stringify(detail) : detail;
+        const [result] = await db.query(
+            'INSERT INTO audit_log (action, actor, detail, ip_address) VALUES (?, ?, ?, ?)',
+            [action, actor, detailJson, ipAddress]
+        );
+        return result.insertId;
+    },
+
+    /**
+     * Get recent audit log entries.
+     * @param {number} [limit=50] - Max entries to return
+     * @returns {Promise<Array>} Log entries, newest first
+     */
+    async getRecent(limit = 50) {
+        const db = getDatabase();
+        const [rows] = await db.query('SELECT * FROM audit_log ORDER BY created_at DESC LIMIT ?', [limit]);
+        return rows;
+    }
+};
+
+module.exports = AuditLog;

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -8,6 +8,7 @@ const express = require('express');
 const router = express.Router();
 const { requireApiKey } = require('../middleware/apiKey');
 const { startScheduler, stopScheduler, getSchedulerStatus, waitForIngestionIdle } = require('../ingestion/scheduler');
+const AuditLog = require('../models/auditLog');
 
 // All admin routes require API key authentication
 router.use(requireApiKey);
@@ -40,6 +41,12 @@ router.post('/pause-ingestion', async (req, res) => {
             console.log('[Admin] Active ingestion cycle finished');
         }
 
+        await AuditLog.record({
+            action: 'pause_ingestion',
+            detail: { wasInProgress: status.ingestion.inProgress },
+            ipAddress: req.ip
+        });
+
         res.json({
             success: true,
             message: 'Ingestion paused. Active cycle (if any) has completed.',
@@ -55,7 +62,7 @@ router.post('/pause-ingestion', async (req, res) => {
  * POST /api/admin/resume-ingestion
  * Restarts the ingestion scheduler after a deploy pause.
  */
-router.post('/resume-ingestion', (req, res) => {
+router.post('/resume-ingestion', async (req, res) => {
     try {
         const status = getSchedulerStatus();
 
@@ -69,6 +76,11 @@ router.post('/resume-ingestion', (req, res) => {
 
         startScheduler();
         console.log('[Admin] Ingestion scheduler resumed via API');
+
+        await AuditLog.record({
+            action: 'resume_ingestion',
+            ipAddress: req.ip
+        });
 
         res.json({
             success: true,
@@ -221,6 +233,21 @@ router.get('/health', async (req, res) => {
 
     const httpStatus = health.status === 'ok' ? 200 : 503;
     res.status(httpStatus).json(health);
+});
+
+/**
+ * GET /api/admin/audit-log
+ * Returns recent audit log entries. Accepts optional ?limit= query parameter.
+ */
+router.get('/audit-log', async (req, res) => {
+    try {
+        const limit = Math.min(parseInt(req.query.limit, 10) || 50, 200);
+        const entries = await AuditLog.getRecent(limit);
+        res.json({ success: true, data: entries });
+    } catch (error) {
+        console.error('[Admin] Failed to fetch audit log:', error.message);
+        res.status(500).json({ success: false, error: error.message });
+    }
 });
 
 module.exports = router;

--- a/deployment/backup.sh
+++ b/deployment/backup.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Storm Scout - Automated Database Backup (closes #271)
+#
+# Creates a compressed MariaDB/MySQL dump with rotation.
+# Designed to run via cron (daily) or systemd timer.
+#
+# Usage:
+#   ./backup.sh                      # uses defaults
+#   BACKUP_DIR=/mnt/backups ./backup.sh  # custom backup dir
+#
+# Environment variables:
+#   DB_HOST       Database host (default: localhost)
+#   DB_PORT       Database port (default: 3306)
+#   DB_USER       Database user (default: storm_scout)
+#   DB_PASSWORD   Database password (required)
+#   DB_NAME       Database name (default: storm_scout)
+#   BACKUP_DIR    Backup destination (default: /var/backups/storm-scout)
+#   RETENTION_DAYS  Days to keep backups (default: 30)
+
+set -euo pipefail
+
+# Configuration
+DB_HOST="${DB_HOST:-localhost}"
+DB_PORT="${DB_PORT:-3306}"
+DB_USER="${DB_USER:-storm_scout}"
+DB_NAME="${DB_NAME:-storm_scout}"
+BACKUP_DIR="${BACKUP_DIR:-/var/backups/storm-scout}"
+RETENTION_DAYS="${RETENTION_DAYS:-30}"
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+BACKUP_FILE="${BACKUP_DIR}/${DB_NAME}_${TIMESTAMP}.sql.gz"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_info()  { echo -e "${GREEN}[BACKUP]${NC} $1"; }
+log_warn()  { echo -e "${YELLOW}[BACKUP]${NC} $1"; }
+log_error() { echo -e "${RED}[BACKUP]${NC} $1" >&2; }
+
+# Validate password is set
+if [ -z "${DB_PASSWORD:-}" ]; then
+    log_error "DB_PASSWORD is required. Set it in the environment or .env file."
+    exit 1
+fi
+
+# Create backup directory
+mkdir -p "$BACKUP_DIR"
+
+log_info "Starting backup of ${DB_NAME}@${DB_HOST}:${DB_PORT}"
+log_info "Destination: ${BACKUP_FILE}"
+
+# Run mariadb-dump (falls back to mysqldump if mariadb-dump unavailable)
+DUMP_CMD="mariadb-dump"
+if ! command -v mariadb-dump &>/dev/null; then
+    DUMP_CMD="mysqldump"
+fi
+
+if ! command -v "$DUMP_CMD" &>/dev/null; then
+    log_error "Neither mariadb-dump nor mysqldump found in PATH"
+    exit 1
+fi
+
+START_TIME=$(date +%s)
+
+"$DUMP_CMD" \
+    --host="$DB_HOST" \
+    --port="$DB_PORT" \
+    --user="$DB_USER" \
+    --password="$DB_PASSWORD" \
+    --single-transaction \
+    --routines \
+    --triggers \
+    --quick \
+    --lock-tables=false \
+    "$DB_NAME" | gzip > "$BACKUP_FILE"
+
+END_TIME=$(date +%s)
+DURATION=$((END_TIME - START_TIME))
+FILESIZE=$(du -h "$BACKUP_FILE" | cut -f1)
+
+log_info "Backup completed in ${DURATION}s (${FILESIZE})"
+
+# Rotate old backups
+DELETED=$(find "$BACKUP_DIR" -name "${DB_NAME}_*.sql.gz" -mtime +"$RETENTION_DAYS" -delete -print | wc -l)
+if [ "$DELETED" -gt 0 ]; then
+    log_info "Rotated ${DELETED} backups older than ${RETENTION_DAYS} days"
+fi
+
+# List current backups
+BACKUP_COUNT=$(find "$BACKUP_DIR" -name "${DB_NAME}_*.sql.gz" | wc -l)
+log_info "Total backups on disk: ${BACKUP_COUNT}"
+
+log_info "Backup complete: ${BACKUP_FILE}"

--- a/deployment/verify-backup.sh
+++ b/deployment/verify-backup.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Storm Scout - Backup Verification (closes #271)
+#
+# Restores the latest backup to a temporary database and runs a smoke test
+# to verify data integrity. The temp database is dropped after verification.
+#
+# Usage:
+#   ./verify-backup.sh                         # verify latest backup
+#   ./verify-backup.sh /path/to/backup.sql.gz  # verify specific file
+#
+# Environment variables:
+#   DB_HOST       Database host (default: localhost)
+#   DB_PORT       Database port (default: 3306)
+#   DB_USER       Database user (default: storm_scout)
+#   DB_PASSWORD   Database password (required)
+#   DB_NAME       Source database name (default: storm_scout)
+#   BACKUP_DIR    Backup directory (default: /var/backups/storm-scout)
+
+set -euo pipefail
+
+# Configuration
+DB_HOST="${DB_HOST:-localhost}"
+DB_PORT="${DB_PORT:-3306}"
+DB_USER="${DB_USER:-storm_scout}"
+DB_NAME="${DB_NAME:-storm_scout}"
+BACKUP_DIR="${BACKUP_DIR:-/var/backups/storm-scout}"
+VERIFY_DB="${DB_NAME}_verify_$$"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_info()  { echo -e "${GREEN}[VERIFY]${NC} $1"; }
+log_warn()  { echo -e "${YELLOW}[VERIFY]${NC} $1"; }
+log_error() { echo -e "${RED}[VERIFY]${NC} $1" >&2; }
+
+# Validate password
+if [ -z "${DB_PASSWORD:-}" ]; then
+    log_error "DB_PASSWORD is required."
+    exit 1
+fi
+
+# MySQL/MariaDB client command
+MYSQL_CMD="mariadb"
+if ! command -v mariadb &>/dev/null; then
+    MYSQL_CMD="mysql"
+fi
+
+mysql_exec() {
+    "$MYSQL_CMD" --host="$DB_HOST" --port="$DB_PORT" --user="$DB_USER" --password="$DB_PASSWORD" "$@"
+}
+
+# Find backup file
+BACKUP_FILE="${1:-}"
+if [ -z "$BACKUP_FILE" ]; then
+    BACKUP_FILE=$(find "$BACKUP_DIR" -name "${DB_NAME}_*.sql.gz" -printf '%T+ %p\n' 2>/dev/null | sort -r | head -1 | cut -d' ' -f2-)
+    if [ -z "$BACKUP_FILE" ]; then
+        log_error "No backup files found in ${BACKUP_DIR}"
+        exit 1
+    fi
+fi
+
+if [ ! -f "$BACKUP_FILE" ]; then
+    log_error "Backup file not found: ${BACKUP_FILE}"
+    exit 1
+fi
+
+log_info "Verifying backup: ${BACKUP_FILE}"
+FILESIZE=$(du -h "$BACKUP_FILE" | cut -f1)
+log_info "File size: ${FILESIZE}"
+
+# Cleanup function — always drop the temp database
+cleanup() {
+    log_info "Dropping temporary database ${VERIFY_DB}..."
+    mysql_exec -e "DROP DATABASE IF EXISTS \`${VERIFY_DB}\`;" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Create temp database
+log_info "Creating temporary database: ${VERIFY_DB}"
+mysql_exec -e "CREATE DATABASE \`${VERIFY_DB}\`;"
+
+# Restore
+log_info "Restoring backup..."
+START_TIME=$(date +%s)
+gunzip -c "$BACKUP_FILE" | mysql_exec "$VERIFY_DB"
+END_TIME=$(date +%s)
+log_info "Restore completed in $((END_TIME - START_TIME))s"
+
+# Smoke tests
+log_info "Running smoke tests..."
+PASS=0
+FAIL=0
+
+check_table() {
+    local table="$1"
+    local count
+    count=$(mysql_exec "$VERIFY_DB" -N -e "SELECT COUNT(*) FROM \`${table}\`;" 2>/dev/null)
+    if [ $? -eq 0 ]; then
+        log_info "  ${table}: ${count} rows"
+        PASS=$((PASS + 1))
+    else
+        log_error "  ${table}: FAILED to query"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Check core tables exist and are queryable
+check_table "offices"
+check_table "advisories"
+check_table "office_status"
+check_table "alert_types"
+check_table "ingestion_events"
+
+# Check schema_migrations
+MIGRATION_COUNT=$(mysql_exec "$VERIFY_DB" -N -e "SELECT COUNT(*) FROM schema_migrations;" 2>/dev/null || echo "0")
+log_info "  schema_migrations: ${MIGRATION_COUNT} applied"
+PASS=$((PASS + 1))
+
+# Summary
+echo ""
+if [ "$FAIL" -eq 0 ]; then
+    log_info "Verification PASSED (${PASS}/${PASS} checks)"
+    exit 0
+else
+    log_error "Verification FAILED (${FAIL} failures, ${PASS} passed)"
+    exit 1
+fi

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -137,6 +137,39 @@ These items are tracked in the `[Unreleased]` section of `CHANGELOG.md` and are 
 
 ---
 
+## Backup & Recovery
+
+### Strategy
+
+Daily automated MariaDB/MySQL dumps via `deployment/backup.sh`, compressed with gzip, rotated after 30 days. Verification via `deployment/verify-backup.sh` restores to a temporary database and runs smoke tests against core tables.
+
+### RTO / RPO Targets
+
+| Metric | Target | Notes |
+|--------|--------|-------|
+| **RPO** (Recovery Point Objective) | 24 hours | Daily backups; acceptable data loss is one day of ingestion (re-ingestible from NOAA) |
+| **RTO** (Recovery Time Objective) | 1 hour | Restore from latest dump + re-run ingestion to fill the gap |
+
+### Backup Scheduling
+
+```
+# Example cron entry (daily at 2 AM)
+0 2 * * * /path/to/deployment/backup.sh >> /var/log/storm-scout-backup.log 2>&1
+
+# Weekly verification (Sunday at 4 AM)
+0 4 * * 0 /path/to/deployment/verify-backup.sh >> /var/log/storm-scout-verify.log 2>&1
+```
+
+### Recovery Procedure
+
+1. Stop the application: `pm2 stop storm-scout`
+2. Restore: `gunzip -c backup.sql.gz | mariadb storm_scout`
+3. Run migrations: `npm run migrate`
+4. Start the application: `pm2 start storm-scout`
+5. Trigger immediate ingestion: `npm run ingest`
+
+---
+
 ## Key File Index
 
 | File | Purpose |

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "storm-scout-e2e",
+    "private": true,
+    "scripts": {
+        "test": "npx playwright test --config=playwright.config.js",
+        "test:headed": "npx playwright test --config=playwright.config.js --headed",
+        "test:report": "npx playwright show-report"
+    },
+    "devDependencies": {
+        "@playwright/test": "^1.52.0"
+    }
+}

--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -1,0 +1,32 @@
+/**
+ * Playwright E2E Test Configuration
+ * Runs against the local dev server (closes #270)
+ */
+
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+    testDir: './tests',
+    timeout: 30_000,
+    retries: 1,
+    use: {
+        baseURL: process.env.E2E_BASE_URL || 'http://localhost:3000',
+        screenshot: 'only-on-failure',
+        trace: 'on-first-retry'
+    },
+    projects: [
+        {
+            name: 'chromium',
+            use: { browserName: 'chromium' }
+        }
+    ],
+    webServer: process.env.E2E_BASE_URL
+        ? undefined
+        : {
+              command: 'npm start',
+              cwd: '../backend',
+              port: 3000,
+              reuseExistingServer: true,
+              timeout: 30_000
+          }
+});

--- a/e2e/tests/advisories.spec.js
+++ b/e2e/tests/advisories.spec.js
@@ -1,0 +1,31 @@
+/**
+ * Advisory Filtering E2E Tests
+ * Verifies the advisories page loads and filtering works.
+ */
+
+const { test, expect } = require('@playwright/test');
+
+test.describe('Active Advisories', () => {
+    test('loads advisories page', async ({ page }) => {
+        await page.goto('/advisories.html');
+        await expect(page).toHaveTitle(/Storm Scout/);
+        await expect(page.locator('h1, h2, h3').first()).toBeVisible();
+    });
+
+    test('renders advisory table or list', async ({ page }) => {
+        await page.goto('/advisories.html');
+        await page.waitForLoadState('networkidle');
+        // Should have a table or list of advisories
+        const container = page.locator('table, .advisory-list, .card, #advisories-container');
+        await expect(container.first()).toBeVisible({ timeout: 10_000 });
+    });
+
+    test('filter controls are present', async ({ page }) => {
+        await page.goto('/advisories.html');
+        // Check for filter dropdowns or inputs
+        const filters = page.locator('select, input[type="search"], .filter-controls, [data-filter]');
+        // At least some filter mechanism should exist
+        const count = await filters.count();
+        expect(count).toBeGreaterThan(0);
+    });
+});

--- a/e2e/tests/dashboard.spec.js
+++ b/e2e/tests/dashboard.spec.js
@@ -1,0 +1,39 @@
+/**
+ * Dashboard (Overview) E2E Tests
+ * Verifies that the main dashboard loads and renders key elements.
+ */
+
+const { test, expect } = require('@playwright/test');
+
+test.describe('Dashboard', () => {
+    test('loads overview page with title', async ({ page }) => {
+        await page.goto('/');
+        await expect(page).toHaveTitle(/Storm Scout/);
+    });
+
+    test('renders navbar with navigation links', async ({ page }) => {
+        await page.goto('/');
+        const nav = page.locator('.navbar');
+        await expect(nav).toBeVisible();
+        await expect(nav.getByText('Active Advisories')).toBeVisible();
+        await expect(nav.getByText('Offices Impacted')).toBeVisible();
+        await expect(nav.getByText('Map View')).toBeVisible();
+    });
+
+    test('displays last-updated timestamp', async ({ page }) => {
+        await page.goto('/');
+        const lastUpdated = page.locator('#lastUpdated');
+        await expect(lastUpdated).toBeVisible();
+        // Should eventually replace "Loading..." with a value
+        await expect(lastUpdated).not.toHaveText('Loading...', { timeout: 10_000 });
+    });
+
+    test('renders severity summary cards', async ({ page }) => {
+        await page.goto('/');
+        // Wait for JS to populate cards
+        await page.waitForLoadState('networkidle');
+        // The overview page should have summary statistics
+        const mainContent = page.locator('#main-content, main, .container-fluid');
+        await expect(mainContent.first()).toBeVisible();
+    });
+});

--- a/e2e/tests/export.spec.js
+++ b/e2e/tests/export.spec.js
@@ -1,0 +1,34 @@
+/**
+ * Export E2E Tests
+ * Verifies that CSV/PDF export buttons exist and trigger downloads.
+ */
+
+const { test, expect } = require('@playwright/test');
+
+test.describe('Export', () => {
+    test('advisories page has export button', async ({ page }) => {
+        await page.goto('/advisories.html');
+        await page.waitForLoadState('networkidle');
+        const exportBtn = page.locator('button, a').filter({ hasText: /export|download|csv|pdf/i });
+        // Export functionality should be accessible
+        const count = await exportBtn.count();
+        expect(count).toBeGreaterThan(0);
+    });
+
+    test('export triggers download', async ({ page }) => {
+        await page.goto('/advisories.html');
+        await page.waitForLoadState('networkidle');
+        const exportBtn = page.locator('button, a').filter({ hasText: /export|csv/i }).first();
+        if ((await exportBtn.count()) > 0) {
+            const [download] = await Promise.all([
+                page.waitForEvent('download', { timeout: 5_000 }).catch(() => null),
+                exportBtn.click()
+            ]);
+            // If a download was triggered, verify the filename
+            if (download) {
+                const filename = download.suggestedFilename();
+                expect(filename).toMatch(/\.(csv|pdf|xlsx)$/);
+            }
+        }
+    });
+});

--- a/e2e/tests/map.spec.js
+++ b/e2e/tests/map.spec.js
@@ -1,0 +1,28 @@
+/**
+ * Map View E2E Tests
+ * Verifies the map page loads and renders a Leaflet map.
+ */
+
+const { test, expect } = require('@playwright/test');
+
+test.describe('Map View', () => {
+    test('loads map page', async ({ page }) => {
+        await page.goto('/map.html');
+        await expect(page).toHaveTitle(/Storm Scout/);
+    });
+
+    test('renders Leaflet map container', async ({ page }) => {
+        await page.goto('/map.html');
+        // Leaflet adds .leaflet-container to the map div
+        const map = page.locator('.leaflet-container');
+        await expect(map).toBeVisible({ timeout: 10_000 });
+    });
+
+    test('map has tile layers loaded', async ({ page }) => {
+        await page.goto('/map.html');
+        await page.waitForLoadState('networkidle');
+        // Leaflet tile images should be present
+        const tiles = page.locator('.leaflet-tile-loaded');
+        await expect(tiles.first()).toBeVisible({ timeout: 15_000 });
+    });
+});

--- a/e2e/tests/offices.spec.js
+++ b/e2e/tests/offices.spec.js
@@ -1,0 +1,35 @@
+/**
+ * Office Detail E2E Tests
+ * Verifies the offices list and detail page navigation.
+ */
+
+const { test, expect } = require('@playwright/test');
+
+test.describe('Offices', () => {
+    test('loads offices list page', async ({ page }) => {
+        await page.goto('/offices.html');
+        await expect(page).toHaveTitle(/Storm Scout/);
+    });
+
+    test('renders office cards or table rows', async ({ page }) => {
+        await page.goto('/offices.html');
+        await page.waitForLoadState('networkidle');
+        const items = page.locator('.card, tr, .office-item, [data-office-id]');
+        await expect(items.first()).toBeVisible({ timeout: 10_000 });
+    });
+
+    test('navigates to office detail page', async ({ page }) => {
+        await page.goto('/offices.html');
+        await page.waitForLoadState('networkidle');
+        // Click the first office link/card
+        const link = page.locator('a[href*="office-detail"]').first();
+        if ((await link.count()) > 0) {
+            await link.click();
+            await expect(page).toHaveURL(/office-detail/);
+            await page.waitForLoadState('networkidle');
+            // Detail page should show office info
+            const content = page.locator('#main-content, main, .container-fluid');
+            await expect(content.first()).toBeVisible();
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- **#267 Audit logging**: New `audit_log` table, `AuditLog` model, and logging in admin routes (pause/resume ingestion). New `GET /api/admin/audit-log` endpoint for retrieving entries.
- **#270 Playwright E2E tests**: New `e2e/` directory with Playwright config and 5 test files covering dashboard, advisories, map, offices, and export flows.
- **#271 Automated DB backup**: `deployment/backup.sh` (compressed MariaDB dump with 30-day rotation) and `deployment/verify-backup.sh` (restore-to-temp-db smoke test). RTO/RPO targets documented in `docs/ARCHITECTURE.md` and backup setup in `DEPLOY.md`.

## Test plan
- [x] All 129 existing unit tests pass
- [ ] Run `npm run migrate` to apply audit_log migration
- [ ] Verify `POST /api/admin/pause-ingestion` creates audit_log entry
- [ ] Verify `GET /api/admin/audit-log` returns entries
- [ ] Run `cd e2e && npm install && npx playwright test` against running server
- [ ] Run `./deployment/backup.sh` and `./deployment/verify-backup.sh` on staging

Closes #267, closes #270, closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)