### PR TITLE
docs: replace ASCII architecture diagram with SVG

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,21 +9,7 @@
 
 Storm Scout is a Node.js + Express API backend paired with a Bootstrap 5.3 static frontend. It ingests NOAA weather advisories every 15 minutes, matches them to office locations by UGC zone/county codes, and surfaces operational impact through a browser-based dashboard.
 
-```
-NOAA Weather API
-      │
-      ▼
- noaa-ingestor.js  (15-min cron, UGC matching, dedup, VTEC parsing)
-      │
-      ▼
-MySQL/MariaDB  ◄──── advisory_history snapshots (6-hr cron)
-      │
-      ▼
-Express REST API  (cached, rate-limited, gzip-compressed)
-      │
-      ▼
-Bootstrap 5.3 Frontend  (client-side filter/sort/aggregate over full dataset)
-```
+![Storm Scout system architecture](storm-scout-architecture.svg)
 
 ---
 

--- a/docs/storm-scout-architecture.svg
+++ b/docs/storm-scout-architecture.svg
@@ -1,0 +1,100 @@
+<svg width="720" height="680" viewBox="0 0 720 680" xmlns="http://www.w3.org/2000/svg" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif">
+
+  <style>
+    .title { font-size: 14px; font-weight: 600; }
+    .subtitle { font-size: 11.5px; font-weight: 400; }
+    .container-label { font-size: 14px; font-weight: 600; }
+    .container-sub { font-size: 11.5px; font-weight: 400; }
+    .arr { stroke-width: 1.5; }
+  </style>
+
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M2 1L8 5L2 9" fill="none" stroke="context-stroke" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="720" height="680" fill="#fdfdfc" rx="8"/>
+
+  <!-- Title -->
+  <text x="360" y="30" text-anchor="middle" font-size="17" font-weight="700" fill="#2C2C2A">Storm Scout — System architecture</text>
+
+  <!-- ════════════ External APIs ════════════ -->
+  <rect x="115" y="55" width="210" height="50" rx="8" fill="#E6F1FB" stroke="#185FA5" stroke-width="0.75"/>
+  <text class="title" x="220" y="76" text-anchor="middle" fill="#0C447C">NOAA weather API</text>
+  <text class="subtitle" x="220" y="93" text-anchor="middle" fill="#185FA5">api.weather.gov/alerts</text>
+
+  <rect x="395" y="55" width="210" height="50" rx="8" fill="#E6F1FB" stroke="#185FA5" stroke-width="0.75"/>
+  <text class="title" x="500" y="76" text-anchor="middle" fill="#0C447C">NWS observation API</text>
+  <text class="subtitle" x="500" y="93" text-anchor="middle" fill="#185FA5">api.weather.gov/stations</text>
+
+  <!-- Arrows: APIs → Backend -->
+  <line x1="220" y1="105" x2="220" y2="162" class="arr" stroke="#185FA5" marker-end="url(#arrow)"/>
+  <line x1="500" y1="105" x2="500" y2="162" class="arr" stroke="#185FA5" marker-end="url(#arrow)"/>
+
+  <!-- ════════════ Backend Container ════════════ -->
+  <rect x="60" y="168" width="600" height="218" rx="14" fill="#E1F5EE" stroke="#0F6E56" stroke-width="0.75"/>
+  <text class="container-label" x="360" y="194" text-anchor="middle" fill="#085041">Node.js / Express backend</text>
+
+  <!-- Ingestor: NOAA -->
+  <rect x="82" y="210" width="245" height="60" rx="8" fill="#EEEDFE" stroke="#534AB7" stroke-width="0.75"/>
+  <text class="title" x="205" y="233" text-anchor="middle" fill="#3C3489">noaa-ingestor.js</text>
+  <text class="subtitle" x="205" y="253" text-anchor="middle" fill="#534AB7">15-min cron · UGC matching · VTEC dedup</text>
+
+  <!-- Ingestor: Observations -->
+  <rect x="393" y="210" width="245" height="60" rx="8" fill="#EEEDFE" stroke="#534AB7" stroke-width="0.75"/>
+  <text class="title" x="515" y="233" text-anchor="middle" fill="#3C3489">observation-ingestor.js</text>
+  <text class="subtitle" x="515" y="253" text-anchor="middle" fill="#534AB7">Station data polling</text>
+
+  <!-- REST API -->
+  <rect x="200" y="296" width="320" height="56" rx="8" fill="#F1EFE8" stroke="#5F5E5A" stroke-width="0.75"/>
+  <text class="title" x="360" y="318" text-anchor="middle" fill="#2C2C2A">REST API</text>
+  <text class="subtitle" x="360" y="338" text-anchor="middle" fill="#5F5E5A">Cached · Rate-limited · Gzip compressed</text>
+
+  <!-- Internal arrows: ingestors → REST API -->
+  <line x1="205" y1="270" x2="270" y2="296" stroke="#5F5E5A" stroke-width="0.75" stroke-dasharray="4 3"/>
+  <line x1="515" y1="270" x2="450" y2="296" stroke="#5F5E5A" stroke-width="0.75" stroke-dasharray="4 3"/>
+
+  <!-- Arrow: Backend → DB -->
+  <line x1="360" y1="386" x2="360" y2="424" class="arr" stroke="#854F0B" marker-end="url(#arrow)"/>
+
+  <!-- ════════════ Database ════════════ -->
+  <!-- DB cylinder shape -->
+  <ellipse cx="360" cy="436" rx="115" ry="16" fill="#FAEEDA" stroke="#854F0B" stroke-width="0.75"/>
+  <rect x="245" y="436" width="230" height="50" fill="#FAEEDA" stroke="none"/>
+  <line x1="245" y1="436" x2="245" y2="486" stroke="#854F0B" stroke-width="0.75"/>
+  <line x1="475" y1="436" x2="475" y2="486" stroke="#854F0B" stroke-width="0.75"/>
+  <ellipse cx="360" cy="486" rx="115" ry="16" fill="#FAEEDA" stroke="#854F0B" stroke-width="0.75"/>
+  <text class="title" x="360" y="466" text-anchor="middle" fill="#633806">MariaDB / MySQL</text>
+
+  <!-- Arrow: DB → Frontend -->
+  <line x1="360" y1="502" x2="360" y2="540" class="arr" stroke="#993C1D" marker-end="url(#arrow)"/>
+
+  <!-- ════════════ Frontend Container ════════════ -->
+  <rect x="60" y="546" width="600" height="110" rx="14" fill="#FAECE7" stroke="#993C1D" stroke-width="0.75"/>
+  <text class="container-label" x="360" y="572" text-anchor="middle" fill="#712B13">Bootstrap 5.3 frontend (MPA)</text>
+
+  <!-- Page pills -->
+  <rect x="98"  y="586" width="82"  height="26" rx="13" fill="#F0997B" stroke="none"/>
+  <text x="139" y="603" text-anchor="middle" font-size="11" font-weight="600" fill="#4A1B0C">Overview</text>
+
+  <rect x="192" y="586" width="90"  height="26" rx="13" fill="#F0997B" stroke="none"/>
+  <text x="237" y="603" text-anchor="middle" font-size="11" font-weight="600" fill="#4A1B0C">Advisories</text>
+
+  <rect x="294" y="586" width="72"  height="26" rx="13" fill="#F0997B" stroke="none"/>
+  <text x="330" y="603" text-anchor="middle" font-size="11" font-weight="600" fill="#4A1B0C">Offices</text>
+
+  <rect x="378" y="586" width="56"  height="26" rx="13" fill="#F0997B" stroke="none"/>
+  <text x="406" y="603" text-anchor="middle" font-size="11" font-weight="600" fill="#4A1B0C">Map</text>
+
+  <rect x="446" y="586" width="72"  height="26" rx="13" fill="#F0997B" stroke="none"/>
+  <text x="482" y="603" text-anchor="middle" font-size="11" font-weight="600" fill="#4A1B0C">Notices</text>
+
+  <rect x="530" y="586" width="72"  height="26" rx="13" fill="#F0997B" stroke="none"/>
+  <text x="566" y="603" text-anchor="middle" font-size="11" font-weight="600" fill="#4A1B0C">Filters</text>
+
+  <!-- Feature labels -->
+  <text x="360" y="641" text-anchor="middle" font-size="11.5" fill="#993C1D">Leaflet maps · CSV / PDF export · Real-time advisory tracking</text>
+
+</svg>


### PR DESCRIPTION
Replaces the ASCII art architecture diagram in ARCHITECTURE.md with a professional SVG visualization.

## Changes
- Removed ASCII diagram from ARCHITECTURE.md
- Added `storm-scout-architecture.svg` with improved visual clarity
- SVG includes all system components: NOAA/NWS APIs, Node.js/Express backend, MariaDB database, and Bootstrap frontend
- Enhanced readability with color-coded sections and labeled data flows