### PR TITLE
Fix map tiles blocked by narrowed CSP imgSrc

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -74,7 +74,7 @@ app.use(
                     "'self'",
                     'data:', // For inline images and icons
                     'www.googletagmanager.com',
-                    'tile.openstreetmap.org' // Map tiles for Leaflet
+                    '*.tile.openstreetmap.org' // Map tiles for Leaflet (wildcard covers CDN subdomains)
                 ],
                 connectSrc: [
                     "'self'",


### PR DESCRIPTION
## Summary
- Restores wildcard `*.tile.openstreetmap.org` in the CSP `imgSrc` directive
- The previous fix narrowed it to `tile.openstreetmap.org`, which blocked tiles served from CDN subdomains (`a/b/c.tile.openstreetmap.org`)
- One-line change in `backend/src/app.js`

## Test plan
- [ ] Open `map.html` — tile background should render correctly
- [ ] No CSP violation errors in browser DevTools console
- [ ] All backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)