### PR TITLE
Fix filter cards grid layout at smaller viewports

### DIFF
--- a/frontend/js/page-filters.js
+++ b/frontend/js/page-filters.js
@@ -296,7 +296,7 @@ function renderAlertTypes() {
             const safeTypeId = escapeHtml(type.replace(/\s+/g, '_'));
 
             htmlContent += html`
-                <div class="col-md-6 col-lg-4 mb-3">
+                <div class="col-sm-6 col-lg-4 mb-3">
                     <div class="card alert-type-card ${raw(!isEnabled ? 'disabled' : '')}">
                         <div class="card-body">
                             <div class="form-check form-switch">


### PR DESCRIPTION
## Summary
- Changes `col-md-6` to `col-sm-6` on filter alert type cards so the 2-column grid activates at 576px+ instead of 768px+
- One-line change in `frontend/js/page-filters.js`

Closes #303

## Test plan
- [ ] Desktop (992px+): 3-column grid per severity group
- [ ] Tablet (576–991px): 2-column grid
- [ ] Mobile (<576px): single column (expected)
- [ ] Toggle switches and presets still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)