### PR TITLE
refactor: unify UI/UX across all pages

### DIFF
--- a/frontend/advisories.html
+++ b/frontend/advisories.html
@@ -67,6 +67,15 @@
                 </div>
             </div>
 
+            <!-- Filter Indicator -->
+            <div class="row mb-2 d-none" id="filterIndicatorRow">
+                <div class="col-12">
+                    <a href="filters.html" class="badge badge-filter-active text-decoration-none" title="Click to manage filters">
+                        <i class="bi bi-funnel-fill"></i> Filters Active: <span id="filterCount">--</span> of <span id="filterTotal">--</span> alert types
+                    </a>
+                </div>
+            </div>
+
             <!-- Filter Warning Banner -->
             <div class="row" id="filterWarningContainer"></div>
 
@@ -106,8 +115,8 @@
                 <div class="col-md-3">
                     <label for="viewFilter" class="visually-hidden">Filter view</label>
                     <select class="form-select" id="viewFilter" title="Filter advisories">
-                        <option value="all">All Alerts</option>
-                        <option value="CUSTOM" selected>Office Default</option>
+                        <option value="all" selected>All Alerts</option>
+                        <option value="CUSTOM">Office Default</option>
                         <option value="OPERATIONS">Operations View</option>
                         <option value="EXECUTIVE">Executive Summary</option>
                         <option value="SAFETY">Safety Focus</option>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -112,7 +112,7 @@
                 <a href="offices.html?weather_impact=red" class="text-decoration-none">
                     <div class="card text-center weather-card card-clickable impact-red h-100">
                         <div class="card-body py-3">
-                            <span class="badge weather-red mb-1"><i class="bi bi-circle-fill" aria-hidden="true"></i> RED</span>
+                            <span class="badge weather-red mb-1"><i class="bi bi-circle-fill" aria-hidden="true"></i> EXTREME</span>
                             <p class="display-6 fw-bold mb-0 text-danger" id="weatherRed">
                                 <span class="spinner-border spinner-border-sm" role="status"><span class="visually-hidden">Loading...</span></span>
                             </p>
@@ -125,7 +125,7 @@
                 <a href="offices.html?weather_impact=orange" class="text-decoration-none">
                     <div class="card text-center weather-card card-clickable impact-orange h-100">
                         <div class="card-body py-3">
-                            <span class="badge weather-orange mb-1"><i class="bi bi-circle-fill" aria-hidden="true"></i> ORANGE</span>
+                            <span class="badge weather-orange mb-1"><i class="bi bi-circle-fill" aria-hidden="true"></i> SEVERE</span>
                             <p class="display-6 fw-bold mb-0 text-warning" id="weatherOrange">
                                 <span class="spinner-border spinner-border-sm" role="status"><span class="visually-hidden">Loading...</span></span>
                             </p>
@@ -138,7 +138,7 @@
                 <a href="offices.html?weather_impact=yellow" class="text-decoration-none">
                     <div class="card text-center weather-card card-clickable impact-yellow h-100">
                         <div class="card-body py-3">
-                            <span class="badge weather-yellow mb-1"><i class="bi bi-circle-fill" aria-hidden="true"></i> YELLOW</span>
+                            <span class="badge weather-yellow mb-1"><i class="bi bi-circle-fill" aria-hidden="true"></i> MODERATE</span>
                             <p class="display-6 fw-bold mb-0" id="weatherYellow">
                                 <span class="spinner-border spinner-border-sm" role="status"><span class="visually-hidden">Loading...</span></span>
                             </p>

--- a/frontend/js/page-advisories.js
+++ b/frontend/js/page-advisories.js
@@ -552,8 +552,17 @@ function applyURLParameters() {
     }
 }
 
+function updateFilterIndicator() {
+    const row = document.getElementById('filterIndicatorRow');
+    if (!row || !AlertFilters.alertTypesByLevel) return;
+    document.getElementById('filterCount').textContent = AlertFilters.getEnabledCount();
+    document.getElementById('filterTotal').textContent = AlertFilters.getTotalAlertTypes();
+    row.classList.toggle('d-none', !AlertFilters.hasActiveFilters());
+}
+
 // Initialize: Load filter configs then load advisories
 AlertFilters.init().then(() => {
+    updateFilterIndicator();
     loadAdvisories();
     // Apply URL parameters after advisories are loaded
     setTimeout(() => applyURLParameters(), 100);

--- a/frontend/js/page-filters.js
+++ b/frontend/js/page-filters.js
@@ -276,7 +276,7 @@ function renderAlertTypes() {
                 <div class="col-12">
                     <h4 class="border-bottom pb-2">
                         <span class="badge bg-${raw(color)} impact-badge">${levelName}</span>
-                        ${levelName} Impact Alerts
+                        ${levelName} Alerts
                         <button
                             class="btn btn-sm btn-outline-secondary ms-2"
                             data-toggle-level="${safeLevel}"

--- a/frontend/js/page-map.js
+++ b/frontend/js/page-map.js
@@ -65,6 +65,7 @@ async function loadMapData() {
         const filtersLoaded = await AlertFilters.init();
         debugStep('AlertFilters.init() returned: ' + filtersLoaded);
         if (!filtersLoaded) throw new Error('Alert filter initialization failed');
+        updateFilterIndicator();
 
         debugStep('Fetching advisories, offices, observations...');
         const [allAdvisories, allOffices, obsData] = await Promise.all([
@@ -211,13 +212,14 @@ function updateStats(offices) {
     const counts = {
         extreme: offices.filter((o) => o.highest_severity === 'Extreme').length,
         severe: offices.filter((o) => o.highest_severity === 'Severe').length,
-        moderate: offices.filter((o) => o.highest_severity === 'Moderate').length
+        moderate: offices.filter((o) => o.highest_severity === 'Moderate').length,
+        minor: offices.filter((o) => o.highest_severity === 'Minor').length
     };
 
     document.getElementById('extremeCount').textContent = counts.extreme;
     document.getElementById('severeCount').textContent = counts.severe;
     document.getElementById('moderateCount').textContent = counts.moderate;
-    document.getElementById('totalOfficesCount').textContent = offices.length;
+    document.getElementById('minorCount').textContent = counts.minor;
 }
 
 function updateVisibleCount() {
@@ -237,6 +239,7 @@ function resetMap() {
     document.getElementById('filterExtreme').checked = true;
     document.getElementById('filterSevere').checked = true;
     document.getElementById('filterModerate').checked = true;
+    document.getElementById('filterMinor').checked = true;
     applyFilters();
 }
 
@@ -244,13 +247,14 @@ function applyFilters() {
     const showExtreme = document.getElementById('filterExtreme').checked;
     const showSevere = document.getElementById('filterSevere').checked;
     const showModerate = document.getElementById('filterModerate').checked;
+    const showMinor = document.getElementById('filterMinor').checked;
 
     markers.forEach(({ marker, severity }) => {
         const show =
             (severity === 'Extreme' && showExtreme) ||
             (severity === 'Severe' && showSevere) ||
             (severity === 'Moderate' && showModerate) ||
-            severity === 'Minor';
+            (severity === 'Minor' && showMinor);
 
         if (show) {
             marker.addTo(markerLayer);
@@ -270,7 +274,7 @@ function toggleFilter(severity) {
 }
 
 function updateStatCardStyles() {
-    const filters = ['Extreme', 'Severe', 'Moderate'];
+    const filters = ['Extreme', 'Severe', 'Moderate', 'Minor'];
     filters.forEach((severity) => {
         const checkbox = document.getElementById(`filter${severity}`);
         const card = document.querySelector(`.map-stat-card[data-severity="${severity}"]`);
@@ -288,11 +292,21 @@ function updateStatCardStyles() {
 document.getElementById('filterExtreme').addEventListener('change', applyFilters);
 document.getElementById('filterSevere').addEventListener('change', applyFilters);
 document.getElementById('filterModerate').addEventListener('change', applyFilters);
+document.getElementById('filterMinor').addEventListener('change', applyFilters);
 document.getElementById('fitAllBtn').addEventListener('click', fitAllMarkers);
 document.getElementById('resetMapBtn').addEventListener('click', resetMap);
 document.getElementById('toggleExtreme').addEventListener('click', () => toggleFilter('Extreme'));
 document.getElementById('toggleSevere').addEventListener('click', () => toggleFilter('Severe'));
 document.getElementById('toggleModerate').addEventListener('click', () => toggleFilter('Moderate'));
+document.getElementById('toggleMinor').addEventListener('click', () => toggleFilter('Minor'));
+
+function updateFilterIndicator() {
+    const row = document.getElementById('filterIndicatorRow');
+    if (!row || !AlertFilters.alertTypesByLevel) return;
+    document.getElementById('filterCount').textContent = AlertFilters.getEnabledCount();
+    document.getElementById('filterTotal').textContent = AlertFilters.getTotalAlertTypes();
+    row.classList.toggle('d-none', !AlertFilters.hasActiveFilters());
+}
 
 // Initialize
 initMap();

--- a/frontend/js/page-offices.js
+++ b/frontend/js/page-offices.js
@@ -332,8 +332,17 @@ function applyURLParameters() {
     filterOffices();
 }
 
+function updateFilterIndicator() {
+    const row = document.getElementById('filterIndicatorRow');
+    if (!row || !AlertFilters.alertTypesByLevel) return;
+    document.getElementById('filterCount').textContent = AlertFilters.getEnabledCount();
+    document.getElementById('filterTotal').textContent = AlertFilters.getTotalAlertTypes();
+    row.classList.toggle('d-none', !AlertFilters.hasActiveFilters());
+}
+
 // Initialize filters then load offices
 AlertFilters.init().then(async () => {
+    updateFilterIndicator();
     await loadOffices();
     // Apply URL parameters after offices are loaded
     applyURLParameters();

--- a/frontend/map.html
+++ b/frontend/map.html
@@ -57,6 +57,15 @@
             </div>
         </div>
 
+        <!-- Filter Indicator -->
+        <div class="row mb-2 d-none" id="filterIndicatorRow">
+            <div class="col-12">
+                <a href="filters.html" class="badge badge-filter-active text-decoration-none" title="Click to manage filters">
+                    <i class="bi bi-funnel-fill"></i> Filters Active: <span id="filterCount">--</span> of <span id="filterTotal">--</span> alert types
+                </a>
+            </div>
+        </div>
+
         <!-- Map Controls -->
         <div class="row mb-3">
             <div class="col-md-8">
@@ -73,6 +82,9 @@
                                 
                                 <input type="checkbox" class="btn-check" id="filterModerate" checked>
                                 <label class="btn btn-outline-secondary" for="filterModerate">Moderate</label>
+
+                                <input type="checkbox" class="btn-check" id="filterMinor" checked>
+                                <label class="btn btn-outline-success" for="filterMinor">Minor</label>
                             </div>
                         </div>
                         <div class="col-md-4">
@@ -159,10 +171,10 @@
                 </div>
             </div>
             <div class="col-md-3">
-                <div class="card text-center static-card">
+                <div class="card text-center map-stat-card" id="toggleMinor" data-severity="Minor" title="Click to toggle Minor filter">
                     <div class="card-body">
-                        <h5 id="totalOfficesCount">0</h5>
-                        <small class="text-muted">Total Impacted</small>
+                        <h5 class="text-severity-minor" id="minorCount">0</h5>
+                        <small class="text-muted">Minor Offices</small>
                     </div>
                 </div>
             </div>

--- a/frontend/offices.html
+++ b/frontend/offices.html
@@ -53,6 +53,15 @@
             </div>
         </div>
 
+        <!-- Filter Indicator -->
+        <div class="row mb-2 d-none" id="filterIndicatorRow">
+            <div class="col-12">
+                <a href="filters.html" class="badge badge-filter-active text-decoration-none" title="Click to manage filters">
+                    <i class="bi bi-funnel-fill"></i> Filters Active: <span id="filterCount">--</span> of <span id="filterTotal">--</span> alert types
+                </a>
+            </div>
+        </div>
+
         <!-- Active Filter Banner -->
         <div class="row mb-3 d-none" id="activeFilterBanner">
             <div class="col-12">
@@ -79,7 +88,7 @@
             </div>
             <div class="col-md-2">
                 <select class="form-select" id="weatherImpactFilter">
-                    <option value="">All Weather Impacts</option>
+                    <option value="">All Severities</option>
                     <option value="red">Extreme</option>
                     <option value="orange">Severe</option>
                     <option value="yellow">Moderate</option>


### PR DESCRIPTION
## Summary
- Use canonical NOAA severity labels (Extreme/Severe/Moderate) on overview dashboard badges instead of color names (RED/ORANGE/YELLOW)
- Rename "All Weather Impacts" dropdown to "All Severities" on offices page
- Drop "Impact" from filter page group headings (e.g. "Extreme Alerts" not "Extreme Impact Alerts")
- Add Minor severity toggle button and stat card to map page (replacing static "Total Impacted" card)
- Add consistent filter indicator badge across advisories, offices, and map pages
- Default advisories view dropdown to "All Alerts" instead of "Office Default"

Closes #306, closes #307, closes #308, closes #309, closes #310, closes #311, closes #312

## Test plan
- [ ] Overview page: verify badges show EXTREME, SEVERE, MODERATE labels
- [ ] Offices page: verify dropdown says "All Severities"
- [ ] Filters page: verify group headings say "Extreme Alerts", "Severe Alerts", etc.
- [ ] Map page: verify Minor toggle button works and Minor stat card is clickable
- [ ] All pages: verify filter indicator badge appears when filters are active
- [ ] Advisories page: verify dropdown defaults to "All Alerts"

🤖 Generated with [Claude Code](https://claude.com/claude-code)