### PR TITLE
feat: add sort controls to advisories and offices pages

### DIFF
--- a/frontend/advisories.html
+++ b/frontend/advisories.html
@@ -135,6 +135,15 @@
                         <option value="">All States</option>
                     </select>
                 </div>
+                <div class="col-md-3">
+                    <label for="sortOrder" class="visually-hidden">Sort order</label>
+                    <select class="form-select" id="sortOrder">
+                        <option value="severity" selected>Sort by Severity</option>
+                        <option value="office">Sort by Office Code</option>
+                        <option value="alerts">Sort by Alert Count</option>
+                        <option value="state">Sort by State</option>
+                    </select>
+                </div>
             </div>
 
             <!-- Summary Stats -->

--- a/frontend/js/page-advisories.js
+++ b/frontend/js/page-advisories.js
@@ -114,6 +114,24 @@ async function loadAdvisories() {
 
 // getActionBadge() is defined in js/utils.js
 
+function sortSites(sites) {
+    const order = document.getElementById('sortOrder').value;
+    return [...sites].sort((a, b) => {
+        switch (order) {
+            case 'severity':
+                return b.urgency_score - a.urgency_score;
+            case 'office':
+                return a.office_code.localeCompare(b.office_code, undefined, { numeric: true });
+            case 'alerts':
+                return b.unique_advisory_count - a.unique_advisory_count;
+            case 'state':
+                return a.state.localeCompare(b.state) || b.urgency_score - a.urgency_score;
+            default:
+                return 0;
+        }
+    });
+}
+
 /**
  * Render all offices with active advisories as a grouped HTML table.
  * Each office is represented by a clickable header row summarising its
@@ -165,8 +183,7 @@ function renderGroupedTable(sites, filteredAdvisories) {
                 </div>
             `;
 
-    // Sort offices by office_code ascending
-    const sorted = [...sites].sort((a, b) => a.office_code.localeCompare(b.office_code, undefined, { numeric: true }));
+    const sorted = sortSites(sites);
 
     let rowsHtml = '';
     sorted.forEach((site) => {
@@ -342,8 +359,7 @@ function renderCardView(sites, originalAdvisories) {
                 </div>
             `;
 
-    // Render office cards (sorted by office code ascending)
-    const sorted = [...sites].sort((a, b) => a.office_code.localeCompare(b.office_code, undefined, { numeric: true }));
+    const sorted = sortSites(sites);
     container.innerHTML = sorted
         .map((office) => renderOfficeCard(office, observationsMap[office.office_code]))
         .join('');
@@ -530,6 +546,7 @@ document.getElementById('searchBox').addEventListener('input', debounce(renderAl
 document.getElementById('viewFilter').addEventListener('change', renderAll);
 document.getElementById('stateFilter').addEventListener('change', renderAll);
 document.getElementById('dedupToggle').addEventListener('change', renderAll);
+document.getElementById('sortOrder').addEventListener('change', renderAll);
 document.getElementById('cardViewBtn').addEventListener('click', () => switchView('card'));
 document.getElementById('tableViewBtn').addEventListener('click', () => switchView('table'));
 

--- a/frontend/js/page-offices.js
+++ b/frontend/js/page-offices.js
@@ -128,10 +128,34 @@ function applyFiltersToOffices(offices, advisories) {
         .filter((office) => office !== null); // Remove offices without advisories
 }
 
+function sortOffices(offices) {
+    const order = document.getElementById('sortOrder').value;
+    return [...offices].sort((a, b) => {
+        switch (order) {
+            case 'severity': {
+                const rankA = OfficeAggregator.getSeverityRank(a.highest_severity || 'Minor');
+                const rankB = OfficeAggregator.getSeverityRank(b.highest_severity || 'Minor');
+                return rankB - rankA || (b.advisory_count || 0) - (a.advisory_count || 0);
+            }
+            case 'office':
+                return (a.office_code || '').localeCompare(b.office_code || '', undefined, { numeric: true });
+            case 'alerts':
+                return (b.advisory_count || 0) - (a.advisory_count || 0);
+            case 'state':
+                return (
+                    (a.state || '').localeCompare(b.state || '') ||
+                    OfficeAggregator.getSeverityRank(b.highest_severity || 'Minor') -
+                        OfficeAggregator.getSeverityRank(a.highest_severity || 'Minor')
+                );
+            default:
+                return 0;
+        }
+    });
+}
+
 /**
  * Render the office card grid from the provided list.
- * Offices are sorted highest-severity-first so the most critical locations
- * appear at the top regardless of their alphabetical order.
+ * Offices are sorted by the user-selected sort order.
  *
  * @param {Array<Object>} offices - Enriched office objects (from applyFiltersToOffices)
  * @returns {void}
@@ -147,12 +171,7 @@ function renderOffices(offices) {
         return;
     }
 
-    // Sort by urgency (offices with highest severity first)
-    const sortedOffices = [...offices].sort((a, b) => {
-        const rankA = OfficeAggregator.getSeverityRank(a.highest_severity || 'Minor');
-        const rankB = OfficeAggregator.getSeverityRank(b.highest_severity || 'Minor');
-        return rankB - rankA;
-    });
+    const sortedOffices = sortOffices(offices);
 
     container.innerHTML = sortedOffices
         .map((office) => {
@@ -290,6 +309,7 @@ document.getElementById('weatherImpactFilter').addEventListener('change', functi
     filterOffices();
 });
 document.getElementById('statusFilter').addEventListener('change', filterOffices);
+document.getElementById('sortOrder').addEventListener('change', filterOffices);
 document.getElementById('clearFilterBtn').addEventListener('click', clearWeatherFilter);
 
 /**

--- a/frontend/offices.html
+++ b/frontend/offices.html
@@ -102,6 +102,14 @@
                     <option value="At Risk">At Risk</option>
                 </select>
             </div>
+            <div class="col-md-2">
+                <select class="form-select" id="sortOrder">
+                    <option value="severity" selected>Sort by Severity</option>
+                    <option value="office">Sort by Office Code</option>
+                    <option value="alerts">Sort by Alert Count</option>
+                    <option value="state">Sort by State</option>
+                </select>
+            </div>
         </div>
 
         <div class="row" id="officesContainer">


### PR DESCRIPTION
## Summary
- Add "Sort by" dropdown to advisories page (card and table views) and offices page
- Options: Severity (default), Office Code, Alert Count, State
- Changes advisories default sort from alphabetical to severity/urgency so critical alerts surface first
- State sort uses severity as secondary sort within each state

Closes #314, closes #315

## Test plan
- [ ] Advisories card view: default shows highest-severity offices first
- [ ] Switch to "Office Code" — cards re-sort alphabetically
- [ ] Switch to "Alert Count" — offices with most alerts first
- [ ] Switch to "State" — grouped by state, severity within each
- [ ] Advisories table view: same sort options work
- [ ] Offices page: same 4 sort options, default is severity
- [ ] Sort persists when using search box or other filter dropdowns

🤖 Generated with [Claude Code](https://claude.com/claude-code)