### PR TITLE
fix: support subpath deployment with relative API paths

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -32,6 +32,11 @@ NOAA_API_USER_AGENT=StormScout/1.0 (your-real-email@yourcompany.com)
 # ALERT_WEBHOOK_URL=https://hooks.slack.com/services/xxx/yyy/zzz
 # ALERT_EMAIL=ops-team@yourcompany.com
 
+# Subpath Deployment (optional)
+# Set when deploying under a URL subpath (e.g. /stormscout/).
+# Leave unset or '/' for root deployments.
+# BASE_PATH=/stormscout
+
 # CORS Configuration
 CORS_ORIGIN=http://localhost:8080
 

--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -23,6 +23,12 @@ INGESTION_INTERVAL_MINUTES=15
 NOAA_API_BASE_URL=https://api.weather.gov
 NOAA_API_USER_AGENT=StormScout/1.0 (your-team@example.com)
 
+# Subpath Deployment (optional)
+# Set when deploying under a URL subpath (e.g. /stormscout/ on cPanel).
+# Leave unset or '/' for root deployments. Frontend uses relative paths
+# so this is only needed for documentation/reference.
+# BASE_PATH=/stormscout
+
 # CORS Configuration (REQUIRED — no default, omitting blocks all cross-origin requests)
 # Comma-separate multiple origins: https://a.example.com,https://b.example.com
 CORS_ORIGIN=https://your-domain.example.com

--- a/frontend/.htaccess
+++ b/frontend/.htaccess
@@ -1,12 +1,14 @@
 # Storm Scout - Apache/Passenger Routing Configuration
 # This file routes API requests to the Node.js app while serving static frontend files
+# Works at any deployment path (root or subpath like /stormscout/)
 
 # Enable RewriteEngine
 RewriteEngine On
 
 # Route /api/* and /health to the Node.js Passenger app
-RewriteCond %{REQUEST_URI} ^/api/ [OR]
-RewriteCond %{REQUEST_URI} ^/health$
+# Uses relative patterns so this works at any mount point
+RewriteCond %{REQUEST_URI} /api/ [OR]
+RewriteCond %{REQUEST_URI} /health$
 RewriteRule ^(.*)$ - [L,PT]
 
 # Serve static files if they exist
@@ -14,7 +16,7 @@ RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 
 # Default to index.html for single-page app routing
-RewriteRule ^(.*)$ /index.html [L]
+RewriteRule ^(.*)$ index.html [L]
 
 # Set default directory index
 DirectoryIndex index.html

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -5,10 +5,10 @@
  * @generated AI-authored (Claude, Warp) — vanilla JS by design
  */
 
-const API_BASE_URL =
-    window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'
-        ? `${window.location.protocol}//${window.location.host}/api`
-        : '/api';
+// Use a relative path so API calls work at any deployment subpath
+// (e.g. /stormscout/api/... or /api/... — the browser resolves relative
+// to the current page URL automatically).
+const API_BASE_URL = 'api';
 
 const DEFAULT_TIMEOUT_MS = 30000;
 

--- a/frontend/js/page-index.js
+++ b/frontend/js/page-index.js
@@ -460,9 +460,9 @@ initHelpIconKeyboard();
 window.exportCurrentData = async function (type) {
     try {
         // Fetch current data
-        const overviewResponse = await fetch('/api/status/overview');
-        const officesResponse = await fetch('/api/status/offices-impacted');
-        const advisoriesResponse = await fetch('/api/advisories/active');
+        const overviewResponse = await fetch(`${API_BASE_URL}/status/overview`);
+        const officesResponse = await fetch(`${API_BASE_URL}/status/offices-impacted`);
+        const advisoriesResponse = await fetch(`${API_BASE_URL}/advisories/active`);
 
         if (!overviewResponse.ok || !officesResponse.ok || !advisoriesResponse.ok) {
             throw new Error('Failed to fetch data for export');


### PR DESCRIPTION
## Summary
- Switch `API_BASE_URL` from absolute `/api` to relative `api` so all fetch calls resolve correctly at any deployment path (root `/` or subpath `/stormscout/`)
- Fix 3 hardcoded `fetch('/api/...')` calls in `page-index.js` to use `API_BASE_URL`
- Update `.htaccess` rewrite rules to use relative patterns instead of hardcoded `/api/` and `/index.html`
- Add `BASE_PATH` documentation to `.env.example` and `.env.production.example`

Closes #318

## Test plan
- [ ] Deploy at root path (`/`) — API calls still work
- [ ] Deploy at subpath (`/stormscout/`) — API calls resolve to `/stormscout/api/...`
- [ ] Dashboard export function works (was using hardcoded fetch paths)
- [ ] All pages load data correctly (advisories, offices, map, filters, notices)
- [ ] `.htaccess` routes API requests to Passenger and falls back to `index.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)