### PR TITLE
docs: update test counts to match actual suite (771 tests, 43 suites)

### DIFF
--- a/.claude/AGENTS.md
+++ b/.claude/AGENTS.md
@@ -55,7 +55,7 @@ All source code in this project is AI-generated (Claude, Warp) under human direc
 - **LocalStorage Resilience**: `alert-filters.js` `loadUserPreferences()` catches `SecurityError`/`SyntaxError`; falls back to default preset and surfaces a Bootstrap Toast notification via `showToast()` in `utils.js`
 - **UpdateBanner Cleanup**: `destroy()` method clears `countdownInterval` and `pollingInterval`; wired to `beforeunload` and `visibilitychange` to stop background tab polling
 - **Empty-State Consistency**: All list pages use shared `renderEmptyHtml()` utility for zero-result states (advisories table, offices page, advisories card view)
-- **Jest Test Suite**: 561 tests across 39 suites; `jest.config.js` configured with `node` and `jsdom` environments; backend unit tests for `apiKey.js` middleware, `advisory.js` model (dedup paths + `findByNaturalKey`), VTEC extraction, NOAA normalization, alerting, metrics, validators, cache, config, cleanup, and all models; integration tests for all routes (advisories, admin, offices, status, notices, filters, observations, trends, history, operational-status, app behavior); frontend unit tests in `tests/unit/frontend/` covering `utils.js` (38), `aggregation.js` (22), `export.js` (13), `alert-filters.js` (42), `api.js`, `update-banner.js`
+- **Jest Test Suite**: 771 tests across 43 suites; `jest.config.js` configured with `node` and `jsdom` environments; backend unit tests for `apiKey.js` middleware, `advisory.js` model (dedup paths + `findByNaturalKey`), VTEC extraction, NOAA normalization, alerting, metrics, validators, cache, config, cleanup, and all models; integration tests for all routes (advisories, admin, offices, status, notices, filters, observations, trends, history, operational-status, app behavior); frontend unit tests in `tests/unit/frontend/` covering `utils.js`, `aggregation.js`, `export.js`, `alert-filters.js`, `api.js`, `update-banner.js`
 - **Automated XSS Audit**: Smoke test includes innerHTML safety check across all frontend files
 - **Version Display**: Footer on all 8 pages shows version number and release date via `/api/version` endpoint
 - **Stale Cache Safeguards**: Self-unregistering SW stub kills orphaned beta-era service worker; versioned asset URLs (`?v=X.Y.Z`) force cache busting on deploy
@@ -779,8 +779,8 @@ bash scripts/smoke-test.sh     # Pre-deploy: validates all API endpoints + front
 - **Environments**: `node` (backend), `jsdom` (frontend — via `@jest-environment jsdom` docblock)
 - **Test location**: `backend/tests/unit/` (backend), `backend/tests/unit/frontend/` (frontend)
 - **Run**: `npm test` or `npm run test:watch`
-- **Total**: 561 tests across 39 suites (446 backend + 115 frontend)
-- **Coverage**: 75.25% lines, 75.48% statements, 65.32% branches, 80.55% functions
+- **Total**: 771 tests across 43 suites (645 backend + 126 frontend)
+- **Coverage**: 100% lines, 99.9% statements, 92.57% branches, 100% functions
 - **Backend tests**: All routes (advisories, admin, offices, status, notices, filters, observations, trends, history, operational-status, app behavior), all models (advisory, advisoryHistory, auditLog, ingestionEvent, notice, observation, office, officeStatus), middleware (apiKey, validate), utilities (alerting, cache, cleanup, config, metrics, normalizer, noaa-ingestor, api-client, vtec-extraction, validators)
 - **Frontend tests**: `utils.js` (escapeHtml, html tagged template, severity badges, date formatting, celsius-to-fahrenheit, timeAgo, isStale, truncate, debounce, render helpers), `aggregation.js` (severity ranking, urgency, dedup, office aggregation, filter warnings), `export.js` (CSV escaping, date formatting, report generation, shareable links), `alert-filters.js` (preset application, filter logic, localStorage handling), `api.js`, `update-banner.js`
 - **Frontend testability**: `module.exports` guards in `utils.js`, `export.js`, `alert-filters.js` enable Node.js `require()` without breaking browser usage

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ The following are intentional scope boundaries for this project, not missing fea
 | **Geographic coverage** | US only | NOAA Weather API covers the 50 US states and territories. International adapters (Environment Canada, MeteoAlarm, SMN) are designed for but not yet implemented. |
 | **User authentication** | Network-level | The dashboard is open to anyone with the URL. Access is controlled via reverse proxy or VPN. The API uses key-based authentication for write operations. |
 | **Architecture** | Single-tenant | One database, one ingestion pipeline, one organization. See [multi-tenant potential](#adapting-for-your-organization) above. |
-| **Automated tests** | Backend + Frontend | 474 tests across 35 suites (Jest + supertest): 359 backend tests covering API routes, ingestion, deduplication, middleware, and models; 115 frontend unit tests covering utilities, aggregation, export, and alert filtering. See [`CONTRIBUTING.md`](CONTRIBUTING.md#test-coverage-notes) for details. |
+| **Automated tests** | Backend + Frontend | 771 tests across 43 suites (Jest + supertest): 645 backend tests covering API routes, ingestion, deduplication, middleware, and models; 126 frontend unit tests covering utilities, aggregation, export, and alert filtering. See [`CONTRIBUTING.md`](CONTRIBUTING.md#test-coverage-notes) for details. |
 | **Infrastructure cost** | Minimal | Runs on a single VPS ($5-10/month). No paid API dependencies — NOAA data is free and public domain. |
 
 ## Roadmap

--- a/docs/DEVELOPMENT-PROCESS.md
+++ b/docs/DEVELOPMENT-PROCESS.md
@@ -4,7 +4,7 @@ How Storm Scout was built using AI-assisted development, from initial concept to
 
 ## Overview
 
-Storm Scout was developed by a technical operations leader using AI coding assistants over approximately one month. The project spans 275 GitHub Issues and 60+ commits, producing a production-grade weather advisory dashboard with 39 test suites (561 tests, 75% line coverage), security hardening, and comprehensive documentation.
+Storm Scout was developed by a technical operations leader using AI coding assistants over approximately one month. The project spans 275 GitHub Issues and 60+ commits, producing a production-grade weather advisory dashboard with 43 test suites (771 tests, 100% line coverage), security hardening, and comprehensive documentation.
 
 This document describes the methodology — not to promote AI tools, but to provide an honest account of what worked, what didn't, and how human expertise shaped every decision.
 
@@ -73,9 +73,7 @@ The workflow followed a consistent pattern:
 
 ### Automated Testing
 
-The backend has 561 tests across 39 suites covering API routes, ingestion logic, advisory deduplication, database queries, middleware, error handling, and frontend utilities (75.25% line coverage). Tests were generated alongside features — not added retroactively — which caught integration issues early.
-
-The frontend has no automated tests. This was a deliberate trade-off: vanilla JavaScript with no build step means standard test runners don't integrate without adding complexity that would undermine the project's simplicity goals. See [`CONTRIBUTING.md`](../CONTRIBUTING.md#test-coverage-notes) for the full rationale.
+The project has 771 tests across 43 suites: 645 backend tests covering API routes, ingestion logic, advisory deduplication, database queries, middleware, and error handling; 126 frontend unit tests covering utilities, aggregation, export, alert filtering, and the API client (100% line coverage). Tests were generated alongside features — not added retroactively — which caught integration issues early. See [`CONTRIBUTING.md`](../CONTRIBUTING.md#test-coverage-notes) for the full rationale.
 
 ### Code Review Process
 


### PR DESCRIPTION
## Summary
- Updated stale test counts in README.md (474 → 771), DEVELOPMENT-PROCESS.md (561 → 771), and AGENTS.md (561 → 771)
- Corrected suite counts (35/39 → 43), backend/frontend split (645/126), and coverage percentages (100% lines, 92.57% branches)
- CHANGELOG.md left unchanged — entries are point-in-time historical records

## Test plan
- [x] `npm test -- --coverage` confirms 771 tests, 43 suites, 100% line coverage
- [ ] Grep for old counts (474, 561, "35 suites", "39 suites") returns only CHANGELOG.md hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)