### PR TITLE
fix: remediate externally-controlled format string in history route

### DIFF
--- a/backend/src/routes/history.js
+++ b/backend/src/routes/history.js
@@ -295,7 +295,7 @@ router.get('/office-trends/:officeId', historyValidators.getOfficeTrends, handle
             }
         });
     } catch (error) {
-        console.error(`Error fetching office trends for office ${req.params.officeId}:`, error);
+        console.error('Error fetching office trends for office %s:', req.params.officeId, error);
         res.status(500).json({ error: 'Failed to fetch office trends' });
     }
 });

--- a/backend/tests/integration/history.route.test.js
+++ b/backend/tests/integration/history.route.test.js
@@ -223,10 +223,17 @@ describe('GET /api/history/severity-trends — error', () => {
 
 describe('GET /api/history/office-trends/:officeId — error', () => {
   test('returns 500 on database error', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     mockQuery.mockRejectedValue(new Error('DB error'));
 
     const res = await request(app).get('/api/history/office-trends/1');
 
     expect(res.status).toBe(500);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Error fetching office trends for office %s:',
+      1,
+      expect.any(Error)
+    );
+    consoleErrorSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- remediate the externally-controlled format string finding in `backend/src/routes/history.js`
- replace template-literal logging with a constant format string and `%s` placeholder
- pass `officeId` and `error` as separate `console.error` arguments
- add integration-test assertion verifying safe logging call shape in the office-trends error path

## Validation
- `npm test -- tests/integration/history.route.test.js` (14 passed)

Co-Authored-By: Oz <oz-agent@warp.dev>