### PR TITLE
fix: patch flatted transitive vulnerability for CI audit gate

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -32,6 +32,9 @@
         "nodemon": "^3.0.2",
         "prettier": "^3.2.0",
         "supertest": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -3944,9 +3947,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },

--- a/backend/package.json
+++ b/backend/package.json
@@ -65,9 +65,11 @@
     "supertest": "^7.0.0"
   },
   "overrides": {
-    "qs": "6.14.2"
+    "qs": "6.14.2",
+    "flatted": "3.4.2"
   },
   "overrideReasons": {
-    "qs": "Pinned to 6.14.2 to patch two transitive-dependency vulnerabilities: CVE-2026-2391 (prototype pollution via qs) and CVE-2026-27903 (minimatch ReDoS via qs transitive chain). Review on each major qs or axios release — remove override once upstream ships a clean version. See docs/security/README.md § Dependency Overrides."
+    "qs": "Pinned to 6.14.2 to patch two transitive-dependency vulnerabilities: CVE-2026-2391 (prototype pollution via qs) and CVE-2026-27903 (minimatch ReDoS via qs transitive chain). Review on each major qs or axios release — remove override once upstream ships a clean version. See docs/security/README.md § Dependency Overrides.",
+    "flatted": "Pinned to 3.4.2 to patch GHSA-rf6f-7fwh-wjgh (prototype pollution via flatted parse() in <=3.4.1), pulled transitively through eslint -> file-entry-cache -> flat-cache. Review on eslint/file-entry-cache upgrades and remove when upstream resolves without this override."
   }
 }

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -37,11 +37,12 @@ This documentation covers security controls, vulnerability tracking, and depende
 | Package | Pinned Version | CVEs Addressed | Review Trigger |
 |---------|---------------|----------------|----------------|
 | `qs` | `6.14.2` | CVE-2026-2391 (prototype pollution), CVE-2026-27903 (ReDoS via minimatch) | Remove override when upstream `axios` or its dependency chain ships `qs ≥ 6.14.2` natively |
+| `flatted` | `3.4.2` | GHSA-rf6f-7fwh-wjgh (prototype pollution via `parse()` in `<=3.4.1`) | Remove override when upstream `eslint`/`file-entry-cache`/`flat-cache` chain resolves to `flatted > 3.4.1` without pinning |
 
 **Maintenance procedure:**
-1. On each `npm audit` finding referencing `qs`, verify whether the installed transitive version is still `6.14.2` or higher.
-2. Run `npm ls qs` after any major dependency upgrade to confirm the pin is still effective.
-3. Remove the `overrides.qs` entry (and its `overrideReasons.qs` companion) once the upstream package resolves the dependency without the pin.
+1. On each `npm audit` finding referencing `qs` or `flatted`, verify whether the installed transitive version remains at or above the pinned safe version.
+2. Run `npm ls qs` and `npm ls flatted` after any major dependency upgrade to confirm pins are still effective.
+3. Remove stale `overrides` entries (and matching `overrideReasons` companions) once upstream resolves the dependency chain without pinning.
 
 ---
 


### PR DESCRIPTION
## Summary
- fix CI audit failure caused by transitive `flatted<=3.4.1` vulnerability (GHSA-rf6f-7fwh-wjgh)
- add `overrides.flatted = 3.4.2` and `overrideReasons.flatted` in `backend/package.json`
- regenerate `backend/package-lock.json` so `npm ci` resolves `flatted@3.4.2`
- document the new override in `docs/security/README.md` under Dependency Overrides

## Validation
- `npm audit --audit-level=high`
- `npm ls flatted`
- `npm test -- tests/integration/history.route.test.js`

Co-Authored-By: Oz <oz-agent@warp.dev>