### PR TITLE
Fix CodeQL missing rate limiting on SPA fallback route

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,7 +31,7 @@ Storm Scout implements the following security controls:
 | Security Headers | helmet.js (CSP, HSTS, X-Frame-Options, X-Content-Type-Options) |
 | CDN Integrity | SRI hashes on all external CDN resources |
 | Input Validation | express-validator on all API endpoints |
-| Rate Limiting | express-rate-limit (30,000 req/60 min general; 20 req/15 min write) |
+| Rate Limiting | express-rate-limit (30,000 req/60 min API; 600 req/15 min SPA fallback; 20 req/15 min write) |
 | API Authentication | Timing-safe API key comparison via `crypto.timingSafeEqual()` |
 | SQL Injection | Parameterized queries only — no string interpolation |
 

--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -54,6 +54,8 @@ LOG_LEVEL=info
 # Override the default 30,000 req/60-min per-IP API limit.
 # Lower this if abuse is detected; raise it if corporate NAT users are still blocked.
 # RATE_LIMIT_API_MAX=30000
+# Override the default 600 req/15-min per-IP SPA fallback limit (index.html catch-all route).
+# RATE_LIMIT_SPA_MAX=600
 
 # DB connection pool size. Raise if pool exhaustion (HTTP 503) is observed under peak load.
 # Verify MariaDB max_connections before increasing (run: SHOW VARIABLES LIKE 'max_connections').

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -13,7 +13,7 @@ const path = require('path');
 const config = require('./config/config');
 const { getDatabase } = require('./config/database');
 const IngestionEvent = require('./models/ingestionEvent');
-const { apiLimiter, writeLimiter, authLimiter } = require('./middleware/rateLimiter');
+const { apiLimiter, writeLimiter, authLimiter, spaFallbackLimiter } = require('./middleware/rateLimiter');
 const { requireApiKey } = require('./middleware/apiKey');
 const { metricsMiddleware, mountMetricsEndpoint } = require('./middleware/metrics');
 
@@ -302,7 +302,7 @@ app.use((err, req, res, next) => {
 // This must be last to avoid catching API routes
 /* istanbul ignore next -- SPA fallback only active when STATIC_FILES_PATH is configured */
 if (config.staticFiles.path) {
-    app.get('*path', (req, res) => {
+    app.get('*path', spaFallbackLimiter, (req, res) => {
         const indexPath = path.resolve(config.staticFiles.path, 'index.html');
         res.sendFile(indexPath);
     });

--- a/backend/src/middleware/rateLimiter.js
+++ b/backend/src/middleware/rateLimiter.js
@@ -63,6 +63,24 @@ const writeLimiter = rateLimit({
 });
 
 /**
+ * SPA fallback limiter
+ * Protects index.html fallback route from high-volume request abuse.
+ * Configurable via RATE_LIMIT_SPA_MAX env var for production tuning.
+ */
+const spaFallbackLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: parseInt(process.env.RATE_LIMIT_SPA_MAX) || 600, // 600 requests per window
+    message: {
+        success: false,
+        error: 'Too many page requests, please try again later',
+        retryAfter: '15 minutes'
+    },
+    standardHeaders: true,
+    legacyHeaders: false,
+    validate: { xForwardedForHeader: false }
+});
+
+/**
  * Very strict limiter for authentication/sensitive endpoints
  * 10 requests per 15 minutes per IP
  * (Not used currently, but available for future auth endpoints)
@@ -83,5 +101,6 @@ const authLimiter = rateLimit({
 module.exports = {
     apiLimiter,
     writeLimiter,
-    authLimiter
+    authLimiter,
+    spaFallbackLimiter
 };

--- a/backend/tests/integration/app.behavior.test.js
+++ b/backend/tests/integration/app.behavior.test.js
@@ -38,6 +38,9 @@ jest.mock('../../src/ingestion/scheduler', () => ({
 }));
 
 const request = require('supertest');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 
 afterEach(() => jest.clearAllMocks());
 
@@ -70,6 +73,44 @@ describe('BASE_PATH stripping', () => {
   test('passes through requests without BASE_PATH prefix', async () => {
     const res = await request(app).get('/ping');
     expect(res.status).toBe(200);
+  });
+});
+
+describe('SPA fallback rate limiting', () => {
+  let app;
+  let tempStaticDir;
+
+  beforeAll(() => {
+    jest.resetModules();
+    tempStaticDir = fs.mkdtempSync(path.join(os.tmpdir(), 'storm-scout-spa-'));
+    fs.writeFileSync(
+      path.join(tempStaticDir, 'index.html'),
+      '<!doctype html><html><body>storm-scout-spa-test</body></html>'
+    );
+    process.env.STATIC_FILES_PATH = tempStaticDir;
+    process.env.RATE_LIMIT_SPA_MAX = '1';
+    app = require('../../src/app');
+  });
+
+  afterAll(() => {
+    delete process.env.STATIC_FILES_PATH;
+    delete process.env.RATE_LIMIT_SPA_MAX;
+    if (tempStaticDir) {
+      fs.rmSync(tempStaticDir, { recursive: true, force: true });
+    }
+  });
+
+  test('returns 429 after exceeding fallback request limit', async () => {
+    const first = await request(app).get('/path');
+    expect(first.status).toBe(200);
+
+    const second = await request(app).get('/path');
+    expect(second.status).toBe(429);
+    expect(second.body).toMatchObject({
+      success: false,
+      error: 'Too many page requests, please try again later',
+      retryAfter: '15 minutes'
+    });
   });
 });
 
@@ -237,7 +278,6 @@ describe('production CORS warning', () => {
 describe('static file serving', () => {
   test('serves static files with cache headers when STATIC_FILES_PATH is set', async () => {
     jest.resetModules();
-    const path = require('path');
     process.env.STATIC_FILES_PATH = path.resolve(__dirname, '../../public');
     const app = require('../../src/app');
     // Request the SPA fallback route

--- a/backend/tests/unit/rateLimiter.test.js
+++ b/backend/tests/unit/rateLimiter.test.js
@@ -14,24 +14,25 @@ jest.mock('express-rate-limit', () => {
   });
 });
 
-const { apiLimiter, writeLimiter, authLimiter } = require('../../src/middleware/rateLimiter');
+const { apiLimiter, writeLimiter, authLimiter, spaFallbackLimiter } = require('../../src/middleware/rateLimiter');
+const [apiConfig, writeConfig, spaConfig, authConfig] = configs;
 
-// apiLimiter is configs[0] (has skip and handler)
+// apiConfig is configs[0] (has skip and handler)
 
 beforeEach(() => jest.spyOn(console, 'error').mockImplementation());
 afterEach(() => jest.restoreAllMocks());
 
 describe('apiLimiter skip function', () => {
   test('returns true for /health path', () => {
-    expect(configs[0].skip({ path: '/health' })).toBe(true);
+    expect(apiConfig.skip({ path: '/health' })).toBe(true);
   });
 
   test('returns false for /offices path', () => {
-    expect(configs[0].skip({ path: '/offices' })).toBe(false);
+    expect(apiConfig.skip({ path: '/offices' })).toBe(false);
   });
 
   test('returns false for root path', () => {
-    expect(configs[0].skip({ path: '/' })).toBe(false);
+    expect(apiConfig.skip({ path: '/' })).toBe(false);
   });
 });
 
@@ -53,10 +54,10 @@ describe('apiLimiter handler function', () => {
     const next = jest.fn();
     const options = {
       statusCode: 429,
-      message: configs[0].message
+      message: apiConfig.message
     };
 
-    configs[0].handler(req, res, next, options);
+    apiConfig.handler(req, res, next, options);
 
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining('[RATE LIMIT]')
@@ -84,9 +85,9 @@ describe('apiLimiter handler function', () => {
       json: jest.fn()
     };
 
-    configs[0].handler(req, res, jest.fn(), {
+    apiConfig.handler(req, res, jest.fn(), {
       statusCode: 429,
-      message: configs[0].message
+      message: apiConfig.message
     });
 
     expect(res.status).toHaveBeenCalledWith(429);
@@ -96,23 +97,29 @@ describe('apiLimiter handler function', () => {
 
 describe('rate limiter configuration', () => {
   test('apiLimiter is created with correct window and max', () => {
-    expect(configs[0].windowMs).toBe(60 * 60 * 1000);
-    expect(configs[0].max).toBe(30000);
+    expect(apiConfig.windowMs).toBe(60 * 60 * 1000);
+    expect(apiConfig.max).toBe(30000);
   });
 
   test('writeLimiter is created with correct window and max', () => {
-    expect(configs[1].windowMs).toBe(15 * 60 * 1000);
-    expect(configs[1].max).toBe(20);
+    expect(writeConfig.windowMs).toBe(15 * 60 * 1000);
+    expect(writeConfig.max).toBe(20);
+  });
+
+  test('spaFallbackLimiter is created with correct window and max', () => {
+    expect(spaConfig.windowMs).toBe(15 * 60 * 1000);
+    expect(spaConfig.max).toBe(600);
   });
 
   test('authLimiter is created with correct window and max', () => {
-    expect(configs[2].windowMs).toBe(15 * 60 * 1000);
-    expect(configs[2].max).toBe(10);
+    expect(authConfig.windowMs).toBe(15 * 60 * 1000);
+    expect(authConfig.max).toBe(10);
   });
 
   test('all limiters export middleware functions', () => {
     expect(typeof apiLimiter).toBe('function');
     expect(typeof writeLimiter).toBe('function');
     expect(typeof authLimiter).toBe('function');
+    expect(typeof spaFallbackLimiter).toBe('function');
   });
 });

--- a/docs/QUICK-REFERENCE.md
+++ b/docs/QUICK-REFERENCE.md
@@ -90,6 +90,7 @@ Set in `backend/.env` (development) or `backend/.env.production` (production).
 | `CORS_ORIGIN` | *(required)* | Allowed CORS origin (no default) |
 | `TRUST_PROXY` | `false` | Set `true` when behind a reverse proxy |
 | `RATE_LIMIT_API_MAX` | `30000` | General API rate limit (requests per 60 min) |
+| `RATE_LIMIT_SPA_MAX` | `600` | SPA fallback rate limit for `index.html` catch-all route (requests per 15 min) |
 | `RATE_LIMIT_WRITE_MAX` | `20` | Write endpoint rate limit (requests per 15 min) |
 | `LOG_FORMAT` | *(unset)* | Set to `json` for structured request logging |
 | `APPLY_MIGRATIONS` | `true` | Set to `false` to skip auto-migrations on deploy |

--- a/docs/api.md
+++ b/docs/api.md
@@ -545,11 +545,12 @@ Response includes `Retry-After` header indicating when the window resets.
 
 ## Rate Limiting
 
-Three rate limit tiers are applied independently:
+Four rate limit tiers are applied independently:
 
 | Tier | Limit | Window | Applies to | Configurable |
 |------|-------|--------|------------|--------------|
 | General | 30,000 requests | 60 minutes | All `/api/*` routes | `RATE_LIMIT_API_MAX` env var |
+| SPA fallback | 600 requests | 15 minutes | Non-API fallback route serving `index.html` | `RATE_LIMIT_SPA_MAX` env var |
 | Write | 20 requests | 15 minutes | `/api/operational-status` write endpoints | `RATE_LIMIT_WRITE_MAX` env var |
 | Admin | API key required | — | `/api/admin/*` | — |
 


### PR DESCRIPTION
## Summary
- add a dedicated `spaFallbackLimiter` in `backend/src/middleware/rateLimiter.js`
- apply the limiter to the SPA catch-all route in `backend/src/app.js` (`app.get('*path', ...)`)
- extend unit/integration coverage for the new limiter behavior
- document `RATE_LIMIT_SPA_MAX` in env and security/API docs

## Validation
- `npm --prefix backend run lint`
- `npm --prefix backend test -- --runTestsByPath tests/unit/rateLimiter.test.js tests/integration/app.behavior.test.js`
- `npm --prefix backend test`

Co-Authored-By: Oz <oz-agent@warp.dev>