### PR TITLE
Fix /stormscout SPA deep links and harden deploy static-path validation

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -161,6 +161,22 @@ PassengerStartupFile src/server.js
 
 **LiteSpeed Passenger does NOT strip `PassengerBaseURI`** from the URL before forwarding to Express. The app receives `/stormscout/api/offices` instead of `/api/offices`. Set `BASE_PATH=/stormscout` in `.env` to enable the prefix-stripping middleware in `app.js`.
 
+### STATIC_FILES_PATH for split app-root/docroot deployments
+
+When Passenger app root and frontend docroot are different directories (common on cPanel), `STATIC_FILES_PATH` must point to the actual frontend directory that contains `index.html`.
+
+Example for this layout:
+- Passenger app root: `/home/username/stormscout`
+- Frontend docroot: `/home/username/your-domain.example.com/stormscout`
+
+Set in app-root `.env`:
+
+```bash
+STATIC_FILES_PATH=/home/username/your-domain.example.com/stormscout
+```
+
+If `STATIC_FILES_PATH` points to a non-existent path (for example `./frontend` when no `frontend/` exists in app root), SPA deep links will return `Cannot GET /stormscout/...`.
+
 ### Installing Dependencies
 
 npm is **not** on the default `$PATH`. Use the cPanel Node.js virtual environment:

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -302,7 +302,7 @@ app.use((err, req, res, next) => {
 // This must be last to avoid catching API routes
 /* istanbul ignore next -- SPA fallback only active when STATIC_FILES_PATH is configured */
 if (config.staticFiles.path) {
-    app.get('*path', spaFallbackLimiter, (req, res) => {
+    app.get('*', spaFallbackLimiter, (req, res) => {
         const indexPath = path.resolve(config.staticFiles.path, 'index.html');
         res.sendFile(indexPath);
     });

--- a/backend/tests/integration/app.behavior.test.js
+++ b/backend/tests/integration/app.behavior.test.js
@@ -76,6 +76,37 @@ describe('BASE_PATH stripping', () => {
   });
 });
 
+describe('BASE_PATH + SPA deep-link fallback', () => {
+  let app;
+  let tempStaticDir;
+
+  beforeAll(() => {
+    process.env.BASE_PATH = '/stormscout';
+    tempStaticDir = fs.mkdtempSync(path.join(os.tmpdir(), 'storm-scout-basepath-spa-'));
+    fs.writeFileSync(
+      path.join(tempStaticDir, 'index.html'),
+      '<!doctype html><html><body>storm-scout-basepath-spa</body></html>'
+    );
+    process.env.STATIC_FILES_PATH = tempStaticDir;
+    jest.resetModules();
+    app = require('../../src/app');
+  });
+
+  afterAll(() => {
+    delete process.env.BASE_PATH;
+    delete process.env.STATIC_FILES_PATH;
+    if (tempStaticDir) {
+      fs.rmSync(tempStaticDir, { recursive: true, force: true });
+    }
+  });
+
+  test('serves index.html for deep links under BASE_PATH', async () => {
+    const res = await request(app).get('/stormscout/some-route');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('storm-scout-basepath-spa');
+  });
+});
+
 describe('SPA fallback rate limiting', () => {
   let app;
   let tempStaticDir;

--- a/deploy.sh
+++ b/deploy.sh
@@ -220,6 +220,50 @@ deploy_frontend() {
     fi
     log_info "Frontend files synced"
 }
+# Verify remote STATIC_FILES_PATH resolves to a directory containing index.html.
+# This catches split-path cPanel misconfigurations where backend app root and
+# frontend docroot are deployed separately.
+verify_remote_static_files_path() {
+    log_step "Validating remote STATIC_FILES_PATH..."
+
+    $SSH_CMD "$SERVER_USER@$SERVER_HOST" /bin/bash << EOF
+        set -e
+        BACKEND_PATH="$SERVER_BACKEND_PATH"
+        BACKEND_PATH="\${BACKEND_PATH/#\~/\$HOME}"
+        ENV_FILE="\$BACKEND_PATH/.env"
+
+        if [ ! -f "\$ENV_FILE" ]; then
+            echo "[ERROR] Missing environment file: \$ENV_FILE"
+            exit 1
+        fi
+
+        STATIC_RAW=\$(grep -E '^STATIC_FILES_PATH=' "\$ENV_FILE" | tail -n 1 | cut -d= -f2-)
+        if [ -z "\$STATIC_RAW" ]; then
+            echo "[ERROR] STATIC_FILES_PATH is not set in \$ENV_FILE"
+            exit 1
+        fi
+
+        if [[ "\$STATIC_RAW" == /* ]]; then
+            STATIC_PATH="\$STATIC_RAW"
+        else
+            STATIC_PATH="\$BACKEND_PATH/\$STATIC_RAW"
+        fi
+
+        if [ ! -d "\$STATIC_PATH" ]; then
+            echo "[ERROR] STATIC_FILES_PATH directory does not exist: \$STATIC_PATH"
+            exit 1
+        fi
+
+        if [ ! -f "\$STATIC_PATH/index.html" ]; then
+            echo "[ERROR] Missing index.html under STATIC_FILES_PATH: \$STATIC_PATH/index.html"
+            exit 1
+        fi
+
+        echo "Resolved STATIC_FILES_PATH: \$STATIC_PATH"
+EOF
+
+    log_info "Remote STATIC_FILES_PATH is valid"
+}
 
 # Install dependencies, run migrations, prepare for restart. (closes #100)
 # Migrations run AFTER npm ci (new migration files may ship with this deploy)
@@ -232,7 +276,9 @@ post_deploy() {
 
     $SSH_CMD "$SERVER_USER@$SERVER_HOST" /bin/bash << EOF
         set -e
-        cd ~/storm-scout
+        APP_ROOT=\"$SERVER_BACKEND_PATH\"
+        APP_ROOT=\"\${APP_ROOT/#\\~/\\$HOME}\"
+        cd \"\\$APP_ROOT\"
 
         # Activate Node environment (if applicable)
         source "${NODE_ENV_ACTIVATE:-/dev/null}" 2>/dev/null || true
@@ -341,6 +387,7 @@ main() {
 
     deploy_backend
     deploy_frontend
+    verify_remote_static_files_path
     post_deploy
     restart_app
 


### PR DESCRIPTION
## Summary
- switch SPA fallback route to an Express 4-compatible catch-all so deep links under `BASE_PATH` resolve to `index.html`
- add integration regression coverage for `/stormscout/<route>` fallback behavior
- document required `STATIC_FILES_PATH` configuration for cPanel split app-root/docroot deployments
- harden `deploy.sh` with explicit static path validation and backend path handling improvements

## Validation
- `bash -n deploy.sh`
- live endpoint checks:
  - `/stormscout` -> `301`
  - `/stormscout/` -> `200`
  - `/stormscout/some-route` -> `200`
  - `/stormscout/health` -> `200`
  - `/stormscout/api/offices` -> `200`
- `npm --prefix backend test` (43 suites, 774 tests passed)
- `E2E_BASE_URL=https://topper.solutions/stormscout npm --prefix e2e test` (22 passed)

## Incident context
This closes the production regression where `/stormscout` deep links returned `Cannot GET ...` after deployment path mismatches and non-compatible fallback matching in production runtime.

Co-Authored-By: Oz <oz-agent@warp.dev>