### PR TITLE
feat: add JSDoc type annotations to models and API responses (#371)

### DIFF
--- a/backend/src/ingestion/noaa-ingestor.js
+++ b/backend/src/ingestion/noaa-ingestor.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * NOAA Weather Data Ingestor
  * Fetches weather alerts from NOAA and updates database
@@ -5,6 +6,13 @@
  *
  * @generated AI-authored (Claude, Warp) — vanilla JS by design
  */
+
+/** @typedef {import('../types').Advisory} Advisory */
+/** @typedef {import('../types').Office} Office */
+/** @typedef {import('../types').IngestionResult} IngestionResult */
+/** @typedef {import('../types').ObservationIngestionResult} ObservationIngestionResult */
+/** @typedef {import('../types').AlertGeoData} AlertGeoData */
+/** @typedef {import('../types').ObservationData} ObservationData */
 
 const { getNOAAAlerts, getLatestObservation } = require('./utils/api-client');
 const {
@@ -29,7 +37,7 @@ let ingestionStartedAt = null;
 
 /**
  * Return current ingestion status (consumed by /health endpoint)
- * @returns {Object} { active: boolean, startedAt: string|null }
+ * @returns {{active: boolean, startedAt: string|null}}
  */
 function getIngestionStatus() {
     return {
@@ -40,6 +48,8 @@ function getIngestionStatus() {
 
 /**
  * Main ingestion function for NOAA weather data
+ * @param {{signal?: AbortSignal}} [options]
+ * @returns {Promise<IngestionResult>}
  */
 async function ingestNOAAData({ signal } = {}) {
     console.log('\n═══ NOAA Weather Data Ingestion Started ═══');
@@ -531,8 +541,9 @@ async function ingestNOAAData({ signal } = {}) {
 /**
  * Ingest latest weather observations for all offices with mapped observation stations.
  * Deduplicates station fetches (multiple offices may share a station).
- * @param {Array} offices - All office objects from database
- * @returns {Object} { total, updated, failed, uniqueStations }
+ * @param {Office[]} offices - All office objects from database
+ * @param {{signal?: AbortSignal}} [options]
+ * @returns {Promise<ObservationIngestionResult>}
  */
 async function ingestObservations(offices, { signal } = {}) {
     console.log('\n═══ Weather Observations Ingestion ═══');
@@ -627,8 +638,8 @@ async function ingestObservations(offices, { signal } = {}) {
 /**
  * Extract geographic identifiers from NOAA alert properties
  * Returns UGC codes, county names, and state codes
- * @param {Object} properties - NOAA alert properties
- * @returns {Object} { ugcCodes: [], counties: [], states: [] }
+ * @param {{affectedZones?: string[], geocode?: {UGC?: string[], SAME?: string[]}, areaDesc?: string, [key: string]: unknown}} properties - NOAA alert properties
+ * @returns {AlertGeoData}
  */
 function extractGeoFromAlert(properties) {
     const ugcCodes = new Set();
@@ -756,7 +767,7 @@ function stateNameToCode(name) {
 
 /**
  * Get last successful ingestion timestamp from the DB event log.
- * @returns {Promise<Object|null>} {lastUpdated: ISO string} or null if never run
+ * @returns {Promise<{lastUpdated: string}|null>} {lastUpdated: ISO string} or null if never run
  */
 async function getLastIngestionTime() {
     try {

--- a/backend/src/models/advisory.js
+++ b/backend/src/models/advisory.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Advisory Model - MySQL/MariaDB
  * Data access layer for advisories table
@@ -5,13 +6,18 @@
  * @generated AI-authored (Claude, Warp) — vanilla JS by design
  */
 
+/** @typedef {import('../types').Advisory} Advisory */
+/** @typedef {import('../types').AdvisoryWithOffice} AdvisoryWithOffice */
+/** @typedef {import('../types').AdvisoryFilters} AdvisoryFilters */
+/** @typedef {import('../types').AdvisoryExistingLookup} AdvisoryExistingLookup */
+
 const { getDatabase } = require('../config/database');
 
 const AdvisoryModel = {
     /**
      * Get all advisories with optional filters
-     * @param {Object} filters - Optional filters (status, severity, state, office_id, advisory_type)
-     * @returns {Promise<Array>} Array of advisory objects with office data
+     * @param {AdvisoryFilters} filters - Optional filters (status, severity, state, office_id, advisory_type)
+     * @returns {Promise<AdvisoryWithOffice[]>} Array of advisory objects with office data
      */
     async getAll(filters = {}) {
         const db = getDatabase();
@@ -75,8 +81,8 @@ const AdvisoryModel = {
 
     /**
      * Get active advisories only
-     * @param {Object} filters - Optional filters
-     * @returns {Promise<Array>} Array of active advisory objects
+     * @param {AdvisoryFilters} filters - Optional filters
+     * @returns {Promise<AdvisoryWithOffice[]>} Array of active advisory objects
      */
     async getActive(filters = {}) {
         return this.getAll({ ...filters, status: 'active' });
@@ -85,7 +91,7 @@ const AdvisoryModel = {
     /**
      * Get advisory by ID
      * @param {number} id - Advisory ID
-     * @returns {Promise<Object|null>} Advisory object or null
+     * @returns {Promise<AdvisoryWithOffice|null>} Advisory object or null
      */
     async getById(id) {
         const db = getDatabase();
@@ -110,7 +116,7 @@ const AdvisoryModel = {
      * Get advisories for a specific office
      * @param {number} officeId - Office ID
      * @param {boolean} activeOnly - Get only active advisories
-     * @returns {Promise<Array>} Array of advisory objects
+     * @returns {Promise<Advisory[]>} Array of advisory objects
      */
     async getByOffice(officeId, activeOnly = false) {
         const db = getDatabase();
@@ -138,7 +144,7 @@ const AdvisoryModel = {
      * Primary deduplication strategy - external_id is unique per alert+office
      * @param {string} externalId - External ID from NOAA API
      * @param {number} officeId - Office ID (required for composite unique lookup)
-     * @returns {Promise<Object|null>} Existing advisory or null
+     * @returns {Promise<Advisory|null>} Existing advisory or null
      */
     async findByExternalID(externalId, officeId) {
         if (!externalId) return null;
@@ -171,11 +177,11 @@ const AdvisoryModel = {
     /**
      * Find advisory by VTEC event ID (persistent identifier)
      * Used to check if an alert update already exists before creating a duplicate
-     * Event ID stays the same across NEW→CON→EXT→EXP updates
+     * Event ID stays the same across NEW->CON->EXT->EXP updates
      * @param {string} vtecEventId - VTEC event ID (e.g., "PAJK.HW.W.0006")
      * @param {number} officeId - Office ID
-     * @param {string} advisoryType - Advisory type (optional for additional validation)
-     * @returns {Promise<Object|null>} Existing advisory or null
+     * @param {string|null} [advisoryType] - Advisory type (optional for additional validation)
+     * @returns {Promise<Advisory|null>} Existing advisory or null
      */
     async findByVTECEventID(vtecEventId, officeId, advisoryType = null) {
         if (!vtecEventId) return null;
@@ -209,7 +215,7 @@ const AdvisoryModel = {
      * @param {string} advisoryType
      * @param {string} source
      * @param {string|null} startTime
-     * @returns {Promise<Object|null>}
+     * @returns {Promise<Advisory|null>}
      */
     async findByNaturalKey(officeId, advisoryType, source, startTime) {
         const db = getDatabase();
@@ -270,13 +276,11 @@ const AdvisoryModel = {
      *   1. Check by external_id (always present, always unique)
      *   2. If not found and has VTEC, check by vtec_event_id
      *   3. Create new or update existing
-     * @param {Object} advisory - Advisory data
-     * @param {Object} [existingLookup] - Optional pre-fetched lookup maps to skip SELECT queries.
+     * @param {Partial<Advisory>} advisory - Advisory data
+     * @param {AdvisoryExistingLookup|null} [existingLookup] - Optional pre-fetched lookup maps to skip SELECT queries.
      *   When provided by the ingestor's bulk pre-fetch, eliminates per-row DB round-trips.
      *   The ER_DUP_ENTRY catch block below remains as a safety net for concurrent inserts.
-     * @param {Map} [existingLookup.byExternalId] - key: `${external_id}|${office_id}`
-     * @param {Map} [existingLookup.byVtec]        - key: `${vtec_event_id}|${office_id}|${advisory_type}`
-     * @returns {Promise<Object>} Created/updated advisory with ID
+     * @returns {Promise<AdvisoryWithOffice|null>} Created/updated advisory with ID
      */
     async create(advisory, existingLookup = null) {
         const db = getDatabase();
@@ -393,8 +397,8 @@ const AdvisoryModel = {
     /**
      * Update advisory
      * @param {number} id - Advisory ID
-     * @param {Object} updates - Fields to update
-     * @returns {Promise<Object|null>} Updated advisory or null
+     * @param {Partial<Advisory>} updates - Fields to update
+     * @returns {Promise<AdvisoryWithOffice|null>} Updated advisory or null
      */
     async update(id, updates) {
         const db = getDatabase();
@@ -449,7 +453,7 @@ const AdvisoryModel = {
     /**
      * Get advisory count by severity
      * @param {boolean} activeOnly - Count only active advisories
-     * @returns {Promise<Array>} Array of {severity, count} objects
+     * @returns {Promise<Array<{severity: string, count: number}>>} Array of {severity, count} objects
      */
     async getCountBySeverity(activeOnly = true) {
         const db = getDatabase();
@@ -471,7 +475,7 @@ const AdvisoryModel = {
     /**
      * Get recently updated advisories
      * @param {number} limit - Max number of results
-     * @returns {Promise<Array>} Array of advisory objects
+     * @returns {Promise<AdvisoryWithOffice[]>} Array of advisory objects
      */
     async getRecentlyUpdated(limit = 10) {
         const db = getDatabase();

--- a/backend/src/models/officeStatus.js
+++ b/backend/src/models/officeStatus.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Office Status Model
  * Data access layer for office_status table
@@ -5,13 +6,17 @@
  * @generated AI-authored (Claude, Warp) — vanilla JS by design
  */
 
+/** @typedef {import('../types').OfficeStatus} OfficeStatus */
+/** @typedef {import('../types').OfficeStatusWithOffice} OfficeStatusWithOffice */
+/** @typedef {import('../types').OfficeStatusData} OfficeStatusData */
+
 const { getDatabase } = require('../config/database');
 
 const OfficeStatusModel = {
     /**
      * Get all office statuses with office information
-     * @param {Object} filters - Optional filters (operational_status)
-     * @returns {Promise<Array>} Array of office status objects with office data
+     * @param {{operational_status?: string, state?: string}} filters - Optional filters
+     * @returns {Promise<OfficeStatusWithOffice[]>} Array of office status objects with office data
      */
     async getAll(filters = {}) {
         const db = getDatabase();
@@ -43,7 +48,7 @@ const OfficeStatusModel = {
     /**
      * Get status for a specific office
      * @param {number} officeId - Office ID
-     * @returns {Promise<Object|null>} Office status object or null
+     * @returns {Promise<OfficeStatusWithOffice|null>} Office status object or null
      */
     async getByOffice(officeId) {
         const db = getDatabase();
@@ -62,7 +67,7 @@ const OfficeStatusModel = {
     /**
      * Get offices by operational status
      * @param {string} status - Operational status
-     * @returns {Array} Array of office status objects
+     * @returns {Promise<OfficeStatusWithOffice[]>} Array of office status objects
      */
     getByStatus(status) {
         return this.getAll({ operational_status: status });
@@ -70,7 +75,7 @@ const OfficeStatusModel = {
 
     /**
      * Get impacted offices (Closed or At Risk)
-     * @returns {Promise<Array>} Array of impacted office objects
+     * @returns {Promise<Array<OfficeStatusWithOffice & {advisory_count: number}>>} Array of impacted office objects
      */
     async getImpacted() {
         const db = getDatabase();
@@ -97,13 +102,8 @@ const OfficeStatusModel = {
     /**
      * Update or create office status
      * @param {number} officeId - Office ID
-     * @param {Object} statusData - Status data object
-     * @param {string} statusData.operational_status - Operational status (open_normal, open_restricted, closed, pending)
-     * @param {string} statusData.weather_impact_level - Weather impact (green, yellow, orange, red)
-     * @param {string} statusData.reason - Legacy reason field
-     * @param {string} statusData.decision_by - Who made the operational decision
-     * @param {string} statusData.decision_reason - Reason for operational decision
-     * @returns {Promise<Object>} Updated office status
+     * @param {OfficeStatusData|string} statusData - Status data object (or legacy string status)
+     * @returns {Promise<OfficeStatusWithOffice|null>} Updated office status
      */
     async upsert(officeId, statusData) {
         const db = getDatabase();
@@ -176,7 +176,7 @@ const OfficeStatusModel = {
      * @param {string} operationalStatus - Operational status (open_normal, open_restricted, closed, pending)
      * @param {string} decisionBy - User who made the decision
      * @param {string} decisionReason - Reason for the decision
-     * @returns {Promise<Object>} Updated office status
+     * @returns {Promise<OfficeStatusWithOffice|null>} Updated office status
      */
     async setOperationalStatus(officeId, operationalStatus, decisionBy, decisionReason) {
         return this.upsert(officeId, {
@@ -188,7 +188,7 @@ const OfficeStatusModel = {
 
     /**
      * Get status count by operational status
-     * @returns {Promise<Array>} Array of {operational_status, count} objects
+     * @returns {Promise<Array<{operational_status: string, count: number}>>} Array of {operational_status, count} objects
      */
     async getCountByStatus() {
         const db = getDatabase();
@@ -213,7 +213,7 @@ const OfficeStatusModel = {
 
     /**
      * Get weather impact level counts
-     * @returns {Promise<Array>} Array of {weather_impact_level, count} objects
+     * @returns {Promise<Array<{weather_impact_level: string, count: number}>>} Array of {weather_impact_level, count} objects
      */
     async getCountByWeatherImpact() {
         const db = getDatabase();
@@ -234,7 +234,7 @@ const OfficeStatusModel = {
 
     /**
      * Bulk update operational status for multiple offices
-     * @param {Array<number>} officeIds - Array of office IDs
+     * @param {number[]} officeIds - Array of office IDs
      * @param {string} operationalStatus - Operational status
      * @param {string} decisionBy - User who made the decision
      * @param {string} decisionReason - Reason for the decision
@@ -261,7 +261,7 @@ const OfficeStatusModel = {
     /**
      * Get recently updated statuses
      * @param {number} limit - Max number of results
-     * @returns {Promise<Array>} Array of recently updated office statuses
+     * @returns {Promise<OfficeStatusWithOffice[]>} Array of recently updated office statuses
      */
     async getRecentlyUpdated(limit = 10) {
         const db = getDatabase();

--- a/backend/src/types.js
+++ b/backend/src/types.js
@@ -1,0 +1,270 @@
+/**
+ * Storm Scout — Backend Type Definitions
+ *
+ * Pure @typedef declarations consumed via JSDoc {@link import} references.
+ * This file exports nothing at runtime — it exists only for editor
+ * intellisense and `checkJs` type checking.
+ *
+ * @generated AI-authored (Claude) — vanilla JS by design
+ */
+
+// ──────────────────────────────────────────────
+// Advisory
+// ──────────────────────────────────────────────
+
+/**
+ * @typedef {Object} Advisory
+ * @property {number}      id
+ * @property {string}      external_id       - NOAA unique identifier for the alert
+ * @property {number}      office_id         - FK to offices.id
+ * @property {string}      advisory_type     - e.g. "Tornado Warning", "Winter Storm Watch"
+ * @property {string}      severity          - "Extreme" | "Severe" | "Moderate" | "Minor" | "Unknown"
+ * @property {string}      status            - "active" | "expired"
+ * @property {string}      source            - Originating zone/area identifier
+ * @property {string|null} headline
+ * @property {string|null} description
+ * @property {string|null} start_time        - ISO datetime
+ * @property {string|null} end_time          - ISO datetime
+ * @property {string|null} issued_time       - ISO datetime
+ * @property {string|null} vtec_code         - Raw VTEC string (legacy)
+ * @property {string|null} vtec_event_id     - Persistent VTEC event ID (e.g. "PAJK.HW.W.0006")
+ * @property {string|null} vtec_action       - "NEW" | "CON" | "EXT" | "UPG" | "EXP" | etc.
+ * @property {string|Object|null} raw_payload - Original NOAA JSON payload
+ * @property {string}      last_updated      - ISO datetime (auto-set by DB)
+ */
+
+/**
+ * Advisory joined with office data (returned by getAll, getById, etc.)
+ * @typedef {Advisory & AdvisoryOfficeJoin} AdvisoryWithOffice
+ */
+
+/**
+ * @typedef {Object} AdvisoryOfficeJoin
+ * @property {string} office_code
+ * @property {string} office_name
+ * @property {string} city
+ * @property {string} state
+ * @property {string} [region]
+ */
+
+/**
+ * Filters accepted by AdvisoryModel.getAll()
+ * @typedef {Object} AdvisoryFilters
+ * @property {string}        [status]        - "active" | "expired"
+ * @property {string|string[]} [severity]    - Single value or comma-separated / array
+ * @property {string|string[]} [advisory_type] - Single value or comma-separated / array
+ * @property {string}        [state]         - Two-letter state code
+ * @property {number}        [office_id]
+ */
+
+/**
+ * Pre-fetched lookup maps passed to AdvisoryModel.create() to skip per-row SELECTs.
+ * @typedef {Object} AdvisoryExistingLookup
+ * @property {Map<string, Advisory>} byExternalId - key: `${external_id}|${office_id}`
+ */
+
+// ──────────────────────────────────────────────
+// Office
+// ──────────────────────────────────────────────
+
+/**
+ * @typedef {Object} Office
+ * @property {number}      id
+ * @property {string}      office_code        - Unique office identifier (e.g. 5-digit zip)
+ * @property {string}      name
+ * @property {string}      city
+ * @property {string}      state              - Two-letter state code
+ * @property {string|null} region
+ * @property {number}      latitude
+ * @property {number}      longitude
+ * @property {string|null} county
+ * @property {string|null} ugc_codes          - JSON array of UGC zone codes
+ * @property {string|null} observation_station - NWS observation station ID
+ */
+
+// ──────────────────────────────────────────────
+// OfficeStatus
+// ──────────────────────────────────────────────
+
+/**
+ * @typedef {Object} OfficeStatus
+ * @property {number}      office_id
+ * @property {string}      operational_status    - "open_normal" | "open_restricted" | "closed" | "pending" (or legacy "Open" | "Closed" | "At Risk")
+ * @property {string|null} weather_impact_level  - "green" | "yellow" | "orange" | "red"
+ * @property {string|null} reason                - Legacy reason text
+ * @property {string|null} decision_by           - Who made the operational decision
+ * @property {string|null} decision_reason       - Reason for the operational decision
+ * @property {string|null} decision_at           - ISO datetime of the decision
+ * @property {string}      last_updated          - ISO datetime
+ */
+
+/**
+ * OfficeStatus joined with office data (returned by getAll, getByOffice, etc.)
+ * @typedef {OfficeStatus & OfficeStatusOfficeJoin} OfficeStatusWithOffice
+ */
+
+/**
+ * @typedef {Object} OfficeStatusOfficeJoin
+ * @property {string}      office_code
+ * @property {string}      name
+ * @property {string}      city
+ * @property {string}      state
+ * @property {string|null} region
+ * @property {number}      [latitude]
+ * @property {number}      [longitude]
+ */
+
+/**
+ * Data accepted by OfficeStatusModel.upsert()
+ * @typedef {Object} OfficeStatusData
+ * @property {string} [operational_status]    - "open_normal" | "open_restricted" | "closed" | "pending"
+ * @property {string} [weather_impact_level]  - "green" | "yellow" | "orange" | "red"
+ * @property {string} [reason]
+ * @property {string} [decision_by]
+ * @property {string} [decision_reason]
+ */
+
+// ──────────────────────────────────────────────
+// Notice
+// ──────────────────────────────────────────────
+
+/**
+ * @typedef {Object} Notice
+ * @property {number}      id
+ * @property {string}      notice_type          - e.g. "Emergency Declaration", "Local Closure"
+ * @property {string}      jurisdiction_type    - "Federal" | "State" | "Local"
+ * @property {string|null} jurisdiction         - Two-letter state code or other identifier
+ * @property {string|null} headline
+ * @property {string|null} description
+ * @property {string}      effective_time       - ISO datetime
+ * @property {string|null} expiration_time      - ISO datetime (null = no expiry)
+ * @property {string}      [created_at]
+ * @property {string}      [updated_at]
+ */
+
+// ──────────────────────────────────────────────
+// Observation
+// ──────────────────────────────────────────────
+
+/**
+ * @typedef {Object} Observation
+ * @property {number}      office_id
+ * @property {string}      station_id           - NWS observation station ID
+ * @property {number|null} temperature_c
+ * @property {number|null} relative_humidity
+ * @property {number|null} dewpoint_c
+ * @property {number|null} wind_speed_kmh
+ * @property {number|null} wind_direction_deg
+ * @property {number|null} wind_gust_kmh
+ * @property {number|null} barometric_pressure_pa
+ * @property {number|null} visibility_m
+ * @property {number|null} wind_chill_c
+ * @property {number|null} heat_index_c
+ * @property {string|null} cloud_layers         - JSON string of cloud layer data
+ * @property {string|null} text_description
+ * @property {string|null} observed_at          - ISO datetime
+ * @property {string}      ingested_at          - ISO datetime (auto-set by DB)
+ */
+
+/**
+ * Observation data accepted by ObservationModel.upsert()
+ * @typedef {Object} ObservationData
+ * @property {string}      station_id
+ * @property {number|null} temperature_c
+ * @property {number|null} relative_humidity
+ * @property {number|null} dewpoint_c
+ * @property {number|null} wind_speed_kmh
+ * @property {number|null} wind_direction_deg
+ * @property {number|null} wind_gust_kmh
+ * @property {number|null} barometric_pressure_pa
+ * @property {number|null} visibility_m
+ * @property {number|null} wind_chill_c
+ * @property {number|null} heat_index_c
+ * @property {string|null} cloud_layers
+ * @property {string|null} text_description
+ * @property {Date|null}   observed_at
+ */
+
+// ──────────────────────────────────────────────
+// AdvisoryHistory
+// ──────────────────────────────────────────────
+
+/**
+ * A single advisory_history row (periodic snapshot of office advisory state).
+ * @typedef {Object} AdvisoryHistorySnapshot
+ * @property {number}      id
+ * @property {number}      office_id
+ * @property {string}      snapshot_time         - ISO datetime
+ * @property {number}      advisory_count
+ * @property {string|null} highest_severity      - "Extreme" | "Severe" | "Moderate" | "Minor"
+ * @property {string|null} highest_severity_type - Advisory type of the highest severity alert
+ * @property {boolean}     has_extreme
+ * @property {boolean}     has_severe
+ * @property {boolean}     has_moderate
+ * @property {number}      new_count             - Number of NEW VTEC actions
+ * @property {number}      upgrade_count         - Number of UPG VTEC actions
+ * @property {string}      advisory_snapshot     - JSON blob of advisory summaries
+ */
+
+/**
+ * Aggregated data passed to AdvisoryHistory.createSnapshot()
+ * @typedef {Object} AggregatedSnapshotData
+ * @property {number}    advisory_count
+ * @property {string}    highest_severity
+ * @property {string}    highest_severity_type
+ * @property {boolean}   has_extreme
+ * @property {boolean}   has_severe
+ * @property {boolean}   has_moderate
+ * @property {number}    new_count
+ * @property {number}    upgrade_count
+ * @property {Array<Advisory>} advisories
+ */
+
+/**
+ * Trend summary returned by AdvisoryHistory.getTrend()
+ * @typedef {Object} AdvisoryTrend
+ * @property {string}  trend              - "worsening" | "improving" | "stable" | "insufficient_data"
+ * @property {number}  [severity_change]
+ * @property {number}  [advisory_change]
+ * @property {string}  [first_severity]
+ * @property {string}  [last_severity]
+ * @property {number}  [first_count]
+ * @property {number}  [last_count]
+ * @property {number}  [duration_hours]
+ * @property {Array<AdvisoryHistorySnapshot>} history
+ */
+
+// ──────────────────────────────────────────────
+// Ingestion
+// ──────────────────────────────────────────────
+
+/**
+ * Result returned by ingestNOAAData()
+ * @typedef {Object} IngestionResult
+ * @property {string} status              - "success" | "partial"
+ * @property {number} advisoriesCreated
+ * @property {number} advisoriesFailed
+ * @property {number} statusesUpdated
+ * @property {number} statusesFailed
+ * @property {number} expiredCount
+ * @property {number} expiredRemoved
+ * @property {number} observationsUpdated
+ * @property {number} observationsTotal
+ */
+
+/**
+ * Result returned by ingestObservations()
+ * @typedef {Object} ObservationIngestionResult
+ * @property {number} total
+ * @property {number} updated
+ * @property {number} failed
+ * @property {number} uniqueStations
+ */
+
+/**
+ * Geographic identifiers extracted from a NOAA alert
+ * @typedef {Object} AlertGeoData
+ * @property {string[]} ugcCodes
+ * @property {string[]} counties   - Format: "STATE|countyname"
+ * @property {string[]} states     - Two-letter state codes
+ */

--- a/frontend/js/aggregation.js
+++ b/frontend/js/aggregation.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Storm Scout Aggregation Logic - Phase 1
  * Groups advisories by office, deduplicates multi-zone alerts, calculates urgency
@@ -5,9 +6,18 @@
  * @generated AI-authored (Claude, Warp) — vanilla JS by design
  */
 
+/** @typedef {import('./types').Advisory} Advisory */
+/** @typedef {import('./types').DeduplicatedAdvisory} DeduplicatedAdvisory */
+/** @typedef {import('./types').AggregatedOffice} AggregatedOffice */
+/** @typedef {import('./types').SeverityGroups} SeverityGroups */
+/** @typedef {import('./types').SummaryStats} SummaryStats */
+/** @typedef {import('./types').FilterWarning} FilterWarning */
+
 const OfficeAggregator = {
     /**
      * Get severity rank for sorting (higher = more severe)
+     * @param {string} severity - "Extreme" | "Severe" | "Moderate" | "Minor" | "Unknown"
+     * @returns {number} Rank (0-4)
      */
     getSeverityRank(severity) {
         const ranks = { Extreme: 4, Severe: 3, Moderate: 2, Minor: 1, Unknown: 0 };
@@ -16,6 +26,8 @@ const OfficeAggregator = {
 
     /**
      * Calculate urgency score for prioritization
+     * @param {Advisory} advisory
+     * @returns {number} Urgency score (higher = more urgent)
      */
     calculateUrgency(advisory) {
         let score = 0;
@@ -46,6 +58,8 @@ const OfficeAggregator = {
     /**
      * Deduplicate multi-zone alerts
      * Groups alerts with same (office_id, advisory_type, severity, issued time window)
+     * @param {Advisory[]} advisories
+     * @returns {DeduplicatedAdvisory[]}
      */
     deduplicateMultiZone(advisories) {
         const dedupMap = new Map();
@@ -91,6 +105,9 @@ const OfficeAggregator = {
 
     /**
      * Group advisories by office and calculate summaries
+     * @param {Advisory[]} advisories
+     * @param {{deduplicateZones?: boolean}} [options]
+     * @returns {AggregatedOffice[]}
      */
     aggregateByOffice(advisories, options = {}) {
         const { deduplicateZones = true } = options;
@@ -186,6 +203,8 @@ const OfficeAggregator = {
     /**
      * Group offices by severity level for dashboard
      * Each severity maps to its own color matching Weather Impact Assessment
+     * @param {AggregatedOffice[]} offices
+     * @returns {SeverityGroups}
      */
     groupBySeverity(offices) {
         return {
@@ -198,6 +217,9 @@ const OfficeAggregator = {
 
     /**
      * Get summary statistics
+     * @param {Advisory[]} advisories
+     * @param {AggregatedOffice[]} offices
+     * @returns {SummaryStats}
      */
     getSummaryStats(advisories, offices) {
         return {
@@ -215,6 +237,9 @@ const OfficeAggregator = {
 
     /**
      * Check if filters are hiding critical alerts
+     * @param {Advisory[]} allAdvisories
+     * @param {Advisory[]} filteredAdvisories
+     * @returns {FilterWarning|null}
      */
     getFilterWarning(allAdvisories, filteredAdvisories) {
         const hiddenCount = allAdvisories.length - filteredAdvisories.length;

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -1,9 +1,19 @@
+// @ts-check
 /**
  * Storm Scout API Client
  * Handles all backend API requests
  *
  * @generated AI-authored (Claude, Warp) — vanilla JS by design
  */
+
+/** @typedef {import('./types').Advisory} Advisory */
+/** @typedef {import('./types').Office} Office */
+/** @typedef {import('./types').ImpactedOffice} ImpactedOffice */
+/** @typedef {import('./types').Notice} Notice */
+/** @typedef {import('./types').Observation} Observation */
+/** @typedef {import('./types').OverviewData} OverviewData */
+/** @typedef {import('./types').TimingData} TimingData */
+/** @typedef {import('./types').VersionInfo} VersionInfo */
 
 // Use a relative path so API calls work at any deployment subpath
 // (e.g. /stormscout/api/... or /api/... — the browser resolves relative
@@ -37,6 +47,7 @@ const API = {
     /**
      * Get app version and release date
      * Cached after first fetch
+     * @returns {Promise<VersionInfo|null>}
      */
     async getVersion() {
         if (_versionCache) return _versionCache;
@@ -54,6 +65,8 @@ const API = {
      * Cached in localStorage for 5 minutes to reduce redundant fetches on
      * page load and tab switches. Hard-refresh (Ctrl+Shift+R) bypasses cache.
      * Max staleness: 5-min client TTL + 15-min ingestion interval = 20 min.
+     * @param {{forceRefresh?: boolean}} [options]
+     * @returns {Promise<OverviewData>}
      */
     async getOverview(options = {}) {
         const { forceRefresh = false } = options;
@@ -92,6 +105,8 @@ const API = {
      * Cached in localStorage for 5 minutes to reduce redundant full-dataset
      * fetches on page load and tab switches.
      * Max staleness: 5-min client TTL + 15-min ingestion interval = 20 min.
+     * @param {{forceRefresh?: boolean}} [options]
+     * @returns {Promise<Advisory[]>}
      */
     async getActiveAdvisories(options = {}) {
         const { forceRefresh = false } = options;
@@ -127,6 +142,7 @@ const API = {
 
     /**
      * Get impacted offices (Closed or At Risk)
+     * @returns {Promise<ImpactedOffice[]>}
      */
     async getImpactedOffices() {
         const response = await fetchWithTimeout(`${API_BASE_URL}/status/offices-impacted`);
@@ -137,6 +153,7 @@ const API = {
 
     /**
      * Get all active government/local notices
+     * @returns {Promise<Notice[]>}
      */
     async getActiveNotices() {
         const response = await fetchWithTimeout(`${API_BASE_URL}/notices/active`);
@@ -149,6 +166,8 @@ const API = {
      * Get all current weather observations
      * Cached in localStorage for 5 minutes — observation data refreshes on
      * the same ingestion cycle as advisories.
+     * @param {{forceRefresh?: boolean}} [options]
+     * @returns {Promise<Observation[]>}
      */
     async getObservations(options = {}) {
         const { forceRefresh = false } = options;
@@ -184,6 +203,7 @@ const API = {
 
     /**
      * Get all offices
+     * @returns {Promise<Office[]>}
      */
     async getOffices() {
         const response = await fetchWithTimeout(`${API_BASE_URL}/offices`);
@@ -195,6 +215,7 @@ const API = {
     /**
      * Get authoritative timing metadata for update countdown synchronization.
      * Always bypasses browser caches.
+     * @returns {Promise<TimingData>}
      */
     async getTiming() {
         const response = await fetchWithTimeout(`${API_BASE_URL}/status/timing`, { cache: 'no-store' });
@@ -205,6 +226,8 @@ const API = {
 
     /**
      * Get trends for all offices (Phase 3)
+     * @param {number} [days=7]
+     * @returns {Promise<{success?: boolean, data?: Array<{[key: string]: unknown}>, status?: string, message?: string}>}
      */
     async getTrends(days = 7) {
         try {
@@ -221,6 +244,9 @@ const API = {
 
     /**
      * Get trend for a specific office (Phase 3)
+     * @param {number} officeId
+     * @param {number} [days=7]
+     * @returns {Promise<{success?: boolean, data?: {[key: string]: unknown}, status?: string, message?: string}>}
      */
     async getOfficeTrend(officeId, days = 7) {
         try {
@@ -237,6 +263,9 @@ const API = {
 
     /**
      * Get full history for an office (Phase 3)
+     * @param {number} officeId
+     * @param {number} [days=7]
+     * @returns {Promise<{success?: boolean, data?: {[key: string]: unknown}, status?: string, message?: string}>}
      */
     async getOfficeHistory(officeId, days = 7) {
         try {
@@ -257,8 +286,8 @@ const API = {
 
     /**
      * Get system-wide overview trends
-     * @param {number} days - Number of days of history (default 3)
-     * @returns {Promise} Trend data with severity counts, sites impacted, etc.
+     * @param {number} [days=3] - Number of days of history
+     * @returns {Promise<{success?: boolean, data?: {[key: string]: unknown}, status?: string, message?: string}>}
      */
     async getOverviewTrends(days = 3) {
         try {
@@ -272,8 +301,8 @@ const API = {
 
     /**
      * Get severity-specific trends for sparklines
-     * @param {number} days - Number of days of history (default 3)
-     * @returns {Promise} Severity trend data (critical, high, moderate, low)
+     * @param {number} [days=3] - Number of days of history
+     * @returns {Promise<{success?: boolean, data?: {[key: string]: unknown}, status?: string, message?: string}>}
      */
     async getSeverityTrends(days = 3) {
         try {
@@ -288,8 +317,8 @@ const API = {
     /**
      * Get per-office advisory count trends
      * @param {number} officeId - Office ID
-     * @param {number} days - Number of days of history (default 3)
-     * @returns {Promise} Office-specific trend data
+     * @param {number} [days=3] - Number of days of history
+     * @returns {Promise<{success?: boolean, data?: {[key: string]: unknown}, status?: string, message?: string}>}
      */
     async getOfficeTrends(officeId, days = 3) {
         try {
@@ -303,7 +332,7 @@ const API = {
 
     /**
      * Check if historical data is available and ready
-     * @returns {Promise} Data availability status
+     * @returns {Promise<{status: string, message?: string, recommendation?: string, [key: string]: unknown}>}
      */
     async getHistoricalDataAvailability() {
         try {

--- a/frontend/js/types.js
+++ b/frontend/js/types.js
@@ -1,0 +1,201 @@
+/**
+ * Storm Scout — Frontend Type Definitions
+ *
+ * Simplified @typedef declarations for API response shapes consumed by
+ * frontend scripts. This file exports nothing at runtime.
+ *
+ * @generated AI-authored (Claude) — vanilla JS by design
+ */
+
+// ──────────────────────────────────────────────
+// API Response Shapes
+// ──────────────────────────────────────────────
+
+/**
+ * Advisory as returned by the /api/advisories endpoints.
+ * @typedef {Object} Advisory
+ * @property {number}      id
+ * @property {string}      external_id
+ * @property {number}      office_id
+ * @property {string}      advisory_type
+ * @property {string}      severity          - "Extreme" | "Severe" | "Moderate" | "Minor" | "Unknown"
+ * @property {string}      status            - "active" | "expired"
+ * @property {string|null} headline
+ * @property {string|null} description
+ * @property {string|null} start_time
+ * @property {string|null} end_time
+ * @property {string|null} issued_time
+ * @property {string|null} vtec_action       - "NEW" | "CON" | "EXT" | "UPG" | "EXP" | etc.
+ * @property {string}      last_updated
+ * @property {string}      source
+ * @property {string}      office_code
+ * @property {string}      office_name
+ * @property {string}      city
+ * @property {string}      state
+ * @property {string}      [region]
+ */
+
+/**
+ * Office as returned by the /api/offices endpoint.
+ * @typedef {Object} Office
+ * @property {number}      id
+ * @property {string}      office_code
+ * @property {string}      name
+ * @property {string}      city
+ * @property {string}      state
+ * @property {string|null} region
+ * @property {number}      latitude
+ * @property {number}      longitude
+ */
+
+/**
+ * Impacted office as returned by /api/status/offices-impacted.
+ * @typedef {Object} ImpactedOffice
+ * @property {number}      office_id
+ * @property {string}      operational_status
+ * @property {string|null} weather_impact_level
+ * @property {string}      office_code
+ * @property {string}      name
+ * @property {string}      city
+ * @property {string}      state
+ * @property {string|null} region
+ * @property {number}      advisory_count
+ */
+
+/**
+ * Notice as returned by /api/notices/active.
+ * @typedef {Object} Notice
+ * @property {number}      id
+ * @property {string}      notice_type
+ * @property {string}      jurisdiction_type
+ * @property {string|null} jurisdiction
+ * @property {string|null} headline
+ * @property {string|null} description
+ * @property {string}      effective_time
+ * @property {string|null} expiration_time
+ */
+
+/**
+ * Weather observation as returned by /api/observations.
+ * @typedef {Object} Observation
+ * @property {number}      office_id
+ * @property {string}      station_id
+ * @property {number|null} temperature_c
+ * @property {number|null} relative_humidity
+ * @property {number|null} wind_speed_kmh
+ * @property {number|null} wind_direction_deg
+ * @property {string|null} text_description
+ * @property {string|null} observed_at
+ * @property {string}      office_code
+ * @property {string}      office_name
+ * @property {string}      city
+ * @property {string}      state
+ */
+
+/**
+ * Dashboard overview data from /api/status/overview.
+ * @typedef {Object} OverviewData
+ * @property {number}  total_offices
+ * @property {number}  impacted_offices
+ * @property {number}  active_advisories
+ * @property {Array<{severity: string, count: number}>} severity_counts
+ * @property {Array<{operational_status: string, count: number}>} status_counts
+ * @property {[key: string]: unknown} [additional] - Additional dynamic fields
+ */
+
+/**
+ * Timing metadata from /api/status/timing.
+ * @typedef {Object} TimingData
+ * @property {string}      lastIngestion     - ISO datetime of last successful ingestion
+ * @property {string|null} nextIngestion     - ISO datetime of next scheduled ingestion
+ * @property {number}      intervalMinutes   - Ingestion interval in minutes
+ */
+
+/**
+ * Version info from /api/version.
+ * @typedef {Object} VersionInfo
+ * @property {string} version
+ * @property {string} releaseDate
+ * @property {string} [environment]
+ */
+
+// ──────────────────────────────────────────────
+// Aggregation Types (used by aggregation.js)
+// ──────────────────────────────────────────────
+
+/**
+ * Advisory after multi-zone deduplication.
+ * @typedef {Advisory & DeduplicatedFields} DeduplicatedAdvisory
+ */
+
+/**
+ * @typedef {Object} DeduplicatedFields
+ * @property {boolean}  is_representative
+ * @property {number}   zone_count
+ * @property {string[]} zones
+ * @property {number[]} related_ids
+ * @property {number}   highest_urgency
+ */
+
+/**
+ * Office aggregation produced by OfficeAggregator.aggregateByOffice().
+ * @typedef {Object} AggregatedOffice
+ * @property {number}              office_id
+ * @property {string}              office_code
+ * @property {string}              office_name
+ * @property {string}              city
+ * @property {string}              state
+ * @property {Array<Advisory|DeduplicatedAdvisory>} advisories
+ * @property {string|null}         highest_severity
+ * @property {number}              highest_severity_rank
+ * @property {string[]}            unique_types
+ * @property {number}              total_zone_count
+ * @property {number}              unique_advisory_count
+ * @property {number}              new_count
+ * @property {number}              continued_count
+ * @property {number}              urgency_score
+ * @property {Array<TypeGroup>}    type_groups
+ * @property {Advisory|null}       highest_severity_advisory
+ */
+
+/**
+ * Advisory type group within an aggregated office.
+ * @typedef {Object} TypeGroup
+ * @property {string}  type
+ * @property {string}  severity
+ * @property {number}  count
+ * @property {number}  zone_count
+ * @property {string|null} expires
+ * @property {string|null} vtec_action
+ * @property {Advisory} representative
+ */
+
+/**
+ * Severity-grouped offices from OfficeAggregator.groupBySeverity().
+ * @typedef {Object} SeverityGroups
+ * @property {AggregatedOffice[]} extreme
+ * @property {AggregatedOffice[]} severe
+ * @property {AggregatedOffice[]} moderate
+ * @property {AggregatedOffice[]} minor
+ */
+
+/**
+ * Summary statistics from OfficeAggregator.getSummaryStats().
+ * @typedef {Object} SummaryStats
+ * @property {number}       total_advisories
+ * @property {number}       unique_offices
+ * @property {number}       extreme_severe_offices
+ * @property {number}       moderate_offices
+ * @property {number}       minor_offices
+ * @property {number}       new_alerts
+ * @property {number|string} avg_alerts_per_office
+ */
+
+/**
+ * Filter warning from OfficeAggregator.getFilterWarning().
+ * @typedef {Object} FilterWarning
+ * @property {number}  hidden_count
+ * @property {number}  critical_hidden
+ * @property {boolean} has_critical
+ * @property {boolean} all_hidden
+ */

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "checkJs": true,
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": false,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true
+  },
+  "include": ["backend/src/**/*.js", "frontend/js/**/*.js"],
+  "exclude": ["node_modules", "backend/node_modules", "e2e"]
+}


### PR DESCRIPTION
## Summary
- Add `jsconfig.json` at project root with `checkJs: true` for VS Code type checking
- Create `backend/src/types.js` with `@typedef` blocks for all core data shapes: Advisory, Office, OfficeStatus, Notice, Observation, AdvisoryHistorySnapshot, and related types
- Create `frontend/js/types.js` with frontend-facing typedefs for API response shapes
- Add `// @ts-check` and typed `@param`/`@returns` annotations to priority files:
  - `backend/src/models/advisory.js`
  - `backend/src/models/officeStatus.js`
  - `backend/src/ingestion/noaa-ingestor.js`
  - `frontend/js/api.js`
  - `frontend/js/aggregation.js`

No runtime behavior changed — annotations only.

## Test plan
- [ ] `cd backend && npm test` — all 842 tests pass
- [ ] Open priority files in VS Code — type errors surface on mismatches, no red squiggles on correct usage

Closes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)