### PR TITLE
chore: bump version to 2.3.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "storm-scout-backend",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "storm-scout-backend",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",
@@ -2691,8 +2691,8 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.3.0.tgz",
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
       "dev": true,
       "license": "MIT"
@@ -6774,7 +6774,7 @@
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "p-limit": "^2.2.0"
+        "p-limit": "^2.3.0"
       },
       "engines": {
         "node": ">=8"
@@ -6797,8 +6797,8 @@
       }
     },
     "node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.3.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true,
       "license": "MIT",
@@ -7366,7 +7366,7 @@
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "xmlchars": "^2.2.0"
+        "xmlchars": "^2.3.0"
       },
       "engines": {
         "node": ">=v12.22.7"
@@ -8585,8 +8585,8 @@
       }
     },
     "node_modules/xmlchars": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.3.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storm-scout-backend",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "releasedDate": "2026-03-29",
   "description": "Storm Scout backend API - Weather advisory dashboard for office locations",
   "main": "src/server.js",

--- a/frontend/advisories.html
+++ b/frontend/advisories.html
@@ -172,13 +172,13 @@
             integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI"
             crossorigin="anonymous"
         ></script>
-        <script src="js/api.js?v=2.2.0"></script>
-        <script src="js/version.js?v=2.2.0"></script>
-        <script src="js/utils.js?v=2.2.0"></script>
-        <script src="js/location-filters.js?v=2.2.0"></script>
-        <script src="js/alert-filters.js?v=2.2.0"></script>
-        <script src="js/update-banner.js?v=2.2.0"></script>
-        <script src="js/aggregation.js?v=2.2.0"></script>
-        <script src="js/page-advisories.js?v=2.2.0"></script>
+        <script src="js/api.js?v=2.3.0"></script>
+        <script src="js/version.js?v=2.3.0"></script>
+        <script src="js/utils.js?v=2.3.0"></script>
+        <script src="js/location-filters.js?v=2.3.0"></script>
+        <script src="js/alert-filters.js?v=2.3.0"></script>
+        <script src="js/update-banner.js?v=2.3.0"></script>
+        <script src="js/aggregation.js?v=2.3.0"></script>
+        <script src="js/page-advisories.js?v=2.3.0"></script>
     </body>
 </html>

--- a/frontend/disclaimer.html
+++ b/frontend/disclaimer.html
@@ -63,7 +63,7 @@
     <!-- include:footer.html -->
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-T3BN3HwSXYBXoGEpGMUMTV8EJhVjLSGMCpp/4LYQVS7jnJ2Bfv/MzUJGeF5PY3c" crossorigin="anonymous"></script>
-    <script src="js/api.js?v=2.2.0"></script>
-    <script src="js/version.js?v=2.2.0"></script>
+    <script src="js/api.js?v=2.3.0"></script>
+    <script src="js/version.js?v=2.3.0"></script>
 </body>
 </html>

--- a/frontend/filters.html
+++ b/frontend/filters.html
@@ -4,7 +4,7 @@
     <!-- include:head.html -->
     <meta name="description" content="Configure which NOAA alert types Storm Scout monitors. Choose from 96 advisory types across 5 impact levels with built-in filter presets.">
     <title>Storm Scout - Filter Configuration</title>
-    <link rel="stylesheet" href="css/filters.css?v=2.2.0">
+    <link rel="stylesheet" href="css/filters.css?v=2.3.0">
 </head>
 <body>
     <!-- include:nav.html -->
@@ -92,10 +92,10 @@
     <!-- include:footer.html -->
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
-    <script src="js/api.js?v=2.2.0"></script>
-    <script src="js/version.js?v=2.2.0"></script>
-    <script src="js/utils.js?v=2.2.0"></script>
-    <script src="js/update-banner.js?v=2.2.0"></script>
-    <script src="js/page-filters.js?v=2.2.0"></script>
+    <script src="js/api.js?v=2.3.0"></script>
+    <script src="js/version.js?v=2.3.0"></script>
+    <script src="js/utils.js?v=2.3.0"></script>
+    <script src="js/update-banner.js?v=2.3.0"></script>
+    <script src="js/page-filters.js?v=2.3.0"></script>
 </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -277,13 +277,13 @@
     <!-- include:footer.html -->
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
-    <script src="js/api.js?v=2.2.0"></script>
-    <script src="js/version.js?v=2.2.0"></script>
-    <script src="js/utils.js?v=2.2.0"></script>
-    <script src="js/location-filters.js?v=2.2.0"></script>
-    <script src="js/alert-filters.js?v=2.2.0"></script>
-    <script src="js/aggregation.js?v=2.2.0"></script>
-    <script src="js/export.js?v=2.2.0"></script>
-    <script src="js/page-index.js?v=2.2.0"></script>
+    <script src="js/api.js?v=2.3.0"></script>
+    <script src="js/version.js?v=2.3.0"></script>
+    <script src="js/utils.js?v=2.3.0"></script>
+    <script src="js/location-filters.js?v=2.3.0"></script>
+    <script src="js/alert-filters.js?v=2.3.0"></script>
+    <script src="js/aggregation.js?v=2.3.0"></script>
+    <script src="js/export.js?v=2.3.0"></script>
+    <script src="js/page-index.js?v=2.3.0"></script>
 </body>
 </html>

--- a/frontend/locations.html
+++ b/frontend/locations.html
@@ -4,7 +4,7 @@
     <!-- include:head.html -->
     <meta name="description" content="Configure which monitored locations Storm Scout includes in dashboard views. Enable or disable individual offices by state.">
     <title>Storm Scout - Location Settings</title>
-    <link rel="stylesheet" href="css/locations.css?v=2.2.0">
+    <link rel="stylesheet" href="css/locations.css?v=2.3.0">
 </head>
 <body>
     <!-- include:nav.html -->
@@ -112,11 +112,11 @@
     <!-- include:footer.html -->
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
-    <script src="js/api.js?v=2.2.0"></script>
-    <script src="js/version.js?v=2.2.0"></script>
-    <script src="js/utils.js?v=2.2.0"></script>
-    <script src="js/update-banner.js?v=2.2.0"></script>
-    <script src="js/location-filters.js?v=2.2.0"></script>
-    <script src="js/page-locations.js?v=2.2.0"></script>
+    <script src="js/api.js?v=2.3.0"></script>
+    <script src="js/version.js?v=2.3.0"></script>
+    <script src="js/utils.js?v=2.3.0"></script>
+    <script src="js/update-banner.js?v=2.3.0"></script>
+    <script src="js/location-filters.js?v=2.3.0"></script>
+    <script src="js/page-locations.js?v=2.3.0"></script>
 </body>
 </html>

--- a/frontend/map.html
+++ b/frontend/map.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha384-sHL9NAb7lN7rfvG5lfHpm643Xkcjzp4jFvuavGOndn6pjVqS6ny56CAt3nsEVT4H" crossorigin="anonymous" />
     <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" integrity="sha384-pmjIAcz2bAn0xukfxADbZIb3t8oRT9Sv0rvO+BR5Csr6Dhqq+nZs59P0pPKQJkEV" crossorigin="anonymous" />
     <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" integrity="sha384-wgw+aLYNQ7dlhK47ZPK7FRACiq7ROZwgFNg0m04avm4CaXS+Z9Y7nMu8yNjBKYC+" crossorigin="anonymous" />
-    <link rel="stylesheet" href="css/map.css?v=2.2.0">
+    <link rel="stylesheet" href="css/map.css?v=2.3.0">
 </head>
 <body>
     <!-- include:nav.html -->
@@ -175,13 +175,13 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha384-cxOPjt7s7Iz04uaHJceBmS+qpjv2JkIHNVcuOrM+YHwZOmJGBXI00mdUXEq65HTH" crossorigin="anonymous"></script>
     <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js" integrity="sha384-eXVCORTRlv4FUUgS/xmOyr66XBVraen8ATNLMESp92FKXLAMiKkerixTiBvXriZr" crossorigin="anonymous"></script>
-    <script src="js/api.js?v=2.2.0"></script>
-    <script src="js/version.js?v=2.2.0"></script>
-    <script src="js/utils.js?v=2.2.0"></script>
-    <script src="js/aggregation.js?v=2.2.0"></script>
-    <script src="js/location-filters.js?v=2.2.0"></script>
-    <script src="js/alert-filters.js?v=2.2.0"></script>
-    <script src="js/update-banner.js?v=2.2.0"></script>
-    <script src="js/page-map.js?v=2.2.0"></script>
+    <script src="js/api.js?v=2.3.0"></script>
+    <script src="js/version.js?v=2.3.0"></script>
+    <script src="js/utils.js?v=2.3.0"></script>
+    <script src="js/aggregation.js?v=2.3.0"></script>
+    <script src="js/location-filters.js?v=2.3.0"></script>
+    <script src="js/alert-filters.js?v=2.3.0"></script>
+    <script src="js/update-banner.js?v=2.3.0"></script>
+    <script src="js/page-map.js?v=2.3.0"></script>
 </body>
 </html>

--- a/frontend/notices.html
+++ b/frontend/notices.html
@@ -48,10 +48,10 @@
     <!-- include:footer.html -->
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
-    <script src="js/api.js?v=2.2.0"></script>
-    <script src="js/version.js?v=2.2.0"></script>
-    <script src="js/utils.js?v=2.2.0"></script>
-    <script src="js/update-banner.js?v=2.2.0"></script>
-    <script src="js/page-notices.js?v=2.2.0"></script>
+    <script src="js/api.js?v=2.3.0"></script>
+    <script src="js/version.js?v=2.3.0"></script>
+    <script src="js/utils.js?v=2.3.0"></script>
+    <script src="js/update-banner.js?v=2.3.0"></script>
+    <script src="js/page-notices.js?v=2.3.0"></script>
 </body>
 </html>

--- a/frontend/office-detail.html
+++ b/frontend/office-detail.html
@@ -142,11 +142,11 @@
     <!-- include:footer.html -->
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
-    <script src="js/api.js?v=2.2.0"></script>
-    <script src="js/version.js?v=2.2.0"></script>
-    <script src="js/utils.js?v=2.2.0"></script>
-    <script src="js/alert-filters.js?v=2.2.0"></script>
-    <script src="js/aggregation.js?v=2.2.0"></script>
-    <script src="js/page-office-detail.js?v=2.2.0"></script>
+    <script src="js/api.js?v=2.3.0"></script>
+    <script src="js/version.js?v=2.3.0"></script>
+    <script src="js/utils.js?v=2.3.0"></script>
+    <script src="js/alert-filters.js?v=2.3.0"></script>
+    <script src="js/aggregation.js?v=2.3.0"></script>
+    <script src="js/page-office-detail.js?v=2.3.0"></script>
 </body>
 </html>

--- a/frontend/offices.html
+++ b/frontend/offices.html
@@ -99,13 +99,13 @@
     <!-- include:footer.html -->
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
-    <script src="js/api.js?v=2.2.0"></script>
-    <script src="js/version.js?v=2.2.0"></script>
-    <script src="js/utils.js?v=2.2.0"></script>
-    <script src="js/location-filters.js?v=2.2.0"></script>
-    <script src="js/alert-filters.js?v=2.2.0"></script>
-    <script src="js/update-banner.js?v=2.2.0"></script>
-    <script src="js/aggregation.js?v=2.2.0"></script>
-    <script src="js/page-offices.js?v=2.2.0"></script>
+    <script src="js/api.js?v=2.3.0"></script>
+    <script src="js/version.js?v=2.3.0"></script>
+    <script src="js/utils.js?v=2.3.0"></script>
+    <script src="js/location-filters.js?v=2.3.0"></script>
+    <script src="js/alert-filters.js?v=2.3.0"></script>
+    <script src="js/update-banner.js?v=2.3.0"></script>
+    <script src="js/aggregation.js?v=2.3.0"></script>
+    <script src="js/page-offices.js?v=2.3.0"></script>
 </body>
 </html>

--- a/frontend/partials/head.html
+++ b/frontend/partials/head.html
@@ -4,7 +4,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css" integrity="sha384-CK2SzKma4jA5H/MXDUU7i1TqZlCFaD4T01vtyDFvPlD97JQyS+IsSh1nI2EFbpyk" crossorigin="anonymous">
-    <link rel="stylesheet" href="css/style.css?v=2.2.0">
-    <link rel="stylesheet" href="css/tooltips.css?v=2.2.0">
-    <link rel="stylesheet" href="css/print.css?v=2.2.0">
-    <link rel="stylesheet" href="css/mobile.css?v=2.2.0">
+    <link rel="stylesheet" href="css/style.css?v=2.3.0">
+    <link rel="stylesheet" href="css/tooltips.css?v=2.3.0">
+    <link rel="stylesheet" href="css/print.css?v=2.3.0">
+    <link rel="stylesheet" href="css/mobile.css?v=2.3.0">

--- a/frontend/sources.html
+++ b/frontend/sources.html
@@ -127,9 +127,9 @@
     <!-- include:footer.html -->
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
-    <script src="js/api.js?v=2.2.0"></script>
-    <script src="js/version.js?v=2.2.0"></script>
-    <script src="js/utils.js?v=2.2.0"></script>
-    <script src="js/update-banner.js?v=2.2.0"></script>
+    <script src="js/api.js?v=2.3.0"></script>
+    <script src="js/version.js?v=2.3.0"></script>
+    <script src="js/utils.js?v=2.3.0"></script>
+    <script src="js/update-banner.js?v=2.3.0"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Bump version `2.2.0` → `2.3.0` across all version references.

- `backend/package.json` + `package-lock.json`
- `frontend/partials/head.html` — CSS cache-busting strings
- All 10 `frontend/*.html` — page-specific CSS/JS `?v=` strings

## What's in 2.3.0
- #370 Server-side HTML partials (~545 lines of boilerplate removed)
- #371 JSDoc type annotations on models and API responses
- #372 `Promise.allSettled` for resilient dashboard data loading
- #373 Frontend tests colocated with source files
- #374 Test suite audit (~411 lines of redundant tests removed)

## Test plan
- [ ] `cd backend && npm test` — all 842 tests pass

Closes the stale #380 (replaced by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)