### PR TITLE
fix: restore correct package versions in lockfile

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -2691,8 +2691,8 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.3.0.tgz",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
       "dev": true,
       "license": "MIT"
@@ -6797,8 +6797,8 @@
       }
     },
     "node_modules/p-try": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.3.0.tgz",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true,
       "license": "MIT",
@@ -7366,7 +7366,7 @@
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "xmlchars": "^2.3.0"
+        "xmlchars": "^2.2.0"
       },
       "engines": {
         "node": ">=v12.22.7"
@@ -8585,8 +8585,8 @@
       }
     },
     "node_modules/xmlchars": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.3.0.tgz",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"


### PR DESCRIPTION
## Problem
The v2.3.0 version bump used `sed 's/2.2.0/2.3.0/g'` on `package-lock.json`, which also corrupted three third-party packages that happened to be on version `2.2.0`:
- `xmlchars` (2.2.0 → incorrectly set to 2.3.0, which doesn't exist on npm)
- `cjs-module-lexer` (2.2.0 → incorrectly set to 2.3.0)
- `p-try` (2.2.0 → incorrectly set to 2.3.0)

This caused `npm ci` to fail with a 404 on `xmlchars-2.3.0.tgz`.

## Fix
Restore the correct `version` and `resolved` fields for the three affected packages. Only `storm-scout-backend` itself should be at `2.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)